### PR TITLE
Set monitoring thread name in efforward test

### DIFF
--- a/src/tests/ef_vi/efforward.c
+++ b/src/tests/ef_vi/efforward.c
@@ -274,6 +274,9 @@ static void* monitor_fn(void* dummy)
   int pkt_rates[2];
   int ms, i;
 
+  /* The thread name is limited to 15 characters so abbreviate. */
+  pthread_setname_np(pthread_self(), "efforward_mon");
+
   for( i = 0; i < 2; ++i )
     prev_pkts[i] = vis[i].n_pkts;
   gettimeofday(&start, NULL);


### PR DESCRIPTION
Useful for cpu profiling and isolation.

Do not check for errors.

pthread_setname_np is non-Posix, but is present in Glibc, FreeBSD, OpenBSD, QNX,
Solaris and AIX, not that any of that matter much.
So do not bother protecting with `#if defined(_GNU_SOURCE)`.