### PR TITLE
Centos9 5.14.0-124 drivers build fix

### DIFF
--- a/src/driver/linux_onload/linux_stats.c
+++ b/src/driver/linux_onload/linux_stats.c
@@ -424,7 +424,7 @@ static int oo_filter_hwports_read(struct seq_file *seq, void *unused)
 }
 static int oo_filter_hwports_open(struct inode *inode, struct file *file)
 {
-    return single_open(file, oo_filter_hwports_read, PDE_DATA(inode));
+    return single_open(file, oo_filter_hwports_read, pde_data(inode));
 }
 static const struct proc_ops oo_filter_hwports_fops = {
     PROC_OPS_SET_OWNER
@@ -440,7 +440,7 @@ static int oo_filter_ipaddrs_read(struct seq_file *seq, void *unused)
 }
 static int oo_filter_ipaddrs_open(struct inode *inode, struct file *file)
 {
-    return single_open(file, oo_filter_ipaddrs_read, PDE_DATA(inode));
+    return single_open(file, oo_filter_ipaddrs_read, pde_data(inode));
 }
 static const struct proc_ops oo_filter_ipaddrs_fops = {
     PROC_OPS_SET_OWNER

--- a/src/driver/linux_resource/bt_stats.c
+++ b/src/driver/linux_resource/bt_stats.c
@@ -87,7 +87,7 @@ efrm_read_pd_stats(struct seq_file *seq, void *s)
 }
 static int efrm_open_pd_stats(struct inode *inode, struct file *file)
 {
-	return single_open(file, efrm_read_pd_stats, PDE_DATA(inode));
+	return single_open(file, efrm_read_pd_stats, pde_data(inode));
 }
 static const struct proc_ops efrm_fops_pd_stats = {
 	PROC_OPS_SET_OWNER

--- a/src/driver/linux_resource/filter.c
+++ b/src/driver/linux_resource/filter.c
@@ -1839,7 +1839,7 @@ static struct seq_operations efrm_read_rules_seq_ops = {
 
 static int efrm_read_rules_seq_open(struct inode* inode, struct file* file) {
   int rc = 0;
-  efrm_interface_name_t* name = PDE_DATA(inode);
+  efrm_interface_name_t* name = pde_data(inode);
   efrm_filter_table_t* table;
   struct net* netns = get_net(current->nsproxy->net_ns);
   if ( !find_table_by_ifname( netns, name->efrm_in_interface_name, &table ) )

--- a/src/driver/linux_resource/kernel_compat.sh
+++ b/src/driver/linux_resource/kernel_compat.sh
@@ -151,6 +151,7 @@ EFRM_HAS_XLNX_EFCT_H			file	include/linux/net/xilinx/xlnx_efct.h
 EFRM_TASK_HAS_CPUMASK		member	struct_task_struct	cpus_mask	include/linux/sched.h
 
 EFRM_HAVE_LOWCASE_PDE_DATA symbol pde_data include/linux/proc_fs.h
+EFRM_HAVE_NETIF_RX_NI symbol netif_rx_ni include/linux/netdevice.h
 # TODO move onload-related stuff from net kernel_compat
 " | egrep -v -e '^#' -e '^$' | sed 's/[ \t][ \t]*/:/g'
 }

--- a/src/driver/linux_resource/kernel_compat.sh
+++ b/src/driver/linux_resource/kernel_compat.sh
@@ -149,6 +149,8 @@ EFRM_HAS_AUXBUS_H			file	include/linux/auxiliary_bus.h
 EFRM_HAS_MOD_DT_AUXBUS_H		file	include/linux/mod_devicetable_auxiliary.h
 EFRM_HAS_XLNX_EFCT_H			file	include/linux/net/xilinx/xlnx_efct.h
 EFRM_TASK_HAS_CPUMASK		member	struct_task_struct	cpus_mask	include/linux/sched.h
+
+EFRM_HAVE_LOWCASE_PDE_DATA symbol pde_data include/linux/proc_fs.h
 # TODO move onload-related stuff from net kernel_compat
 " | egrep -v -e '^#' -e '^$' | sed 's/[ \t][ \t]*/:/g'
 }

--- a/src/driver/linux_resource/kernel_proc.c
+++ b/src/driver/linux_resource/kernel_proc.c
@@ -439,7 +439,7 @@ efrm_resource_read_proc(struct seq_file *seq, void *s)
 }
 static int efrm_resource_open_proc(struct inode *inode, struct file *file)
 {
-	return single_open(file, efrm_resource_read_proc, PDE_DATA(inode));
+	return single_open(file, efrm_resource_read_proc, pde_data(inode));
 }
 static const struct proc_ops efrm_resource_fops_proc = {
 	PROC_OPS_SET_OWNER

--- a/src/include/ci/driver/kernel_compat.h
+++ b/src/include/ci/driver/kernel_compat.h
@@ -54,6 +54,7 @@
 #include <linux/fdtable.h>
 #include <asm/syscall.h>
 #include <net/sock.h>
+#include <linux/filter.h>
 
 #include <driver/linux_resource/autocompat.h>
 #include <ci/tools.h>
@@ -397,5 +398,9 @@ oo_remap_vmalloc_range_partial(struct vm_area_struct *vma, unsigned long uaddr,
 #endif
 }
 
+#ifndef EFRM_HAVE_LOWCASE_PDE_DATA
+/* linux < 5.17 */
+#define pde_data PDE_DATA
+#endif /* ! EFRM_HAVE_LOWCASE_PDE_DATA */
 
 #endif /* DRIVER_LINUX_RESOURCE_KERNEL_COMPAT_H */

--- a/src/include/ci/driver/kernel_compat.h
+++ b/src/include/ci/driver/kernel_compat.h
@@ -403,4 +403,9 @@ oo_remap_vmalloc_range_partial(struct vm_area_struct *vma, unsigned long uaddr,
 #define pde_data PDE_DATA
 #endif /* ! EFRM_HAVE_LOWCASE_PDE_DATA */
 
+#ifdef EFRM_HAVE_NETIF_RX_NI
+/* linux < 5.18 */
+#define netif_rx netif_rx_ni
+#endif /* EFRM_HAVE_NETIF_RX_NI */
+
 #endif /* DRIVER_LINUX_RESOURCE_KERNEL_COMPAT_H */

--- a/src/lib/efthrm/tcp_helper_resource.c
+++ b/src/lib/efthrm/tcp_helper_resource.c
@@ -8291,7 +8291,7 @@ static int oo_inject_packet_kernel(ci_netif* ni, ci_ip_pkt_fmt* pkt)
 
   /* Inject the skb into the kernel.  The return value indicates whether the
    * kernel decided to drop the packet, but we don't need to check that. */
-  netif_rx_ni(skb);
+  netif_rx(skb);
 
   dev_put(dev);
   return 0;


### PR DESCRIPTION
Fix for the #82 

Checked by rebuilding gnu and modules on "old" and "new" kernels. Both are ok.
- "old" CentOS Stream 9 (5.14.0-80.el9.x86_64) `mmakebuildtree --gnu; make -C build/gnu_x86_64/ -j4; mmakebuildtree --driver; make -C build/x86_64_linux-5.14.0-80.el9.x86_64/`
- "new" CentOS Stream 9 (5.14.0-124.el9.x86_64) `mmakebuildtree --gnu; make -C build/gnu_x86_64/ -j4; mmakebuildtree --driver; make -C build/x86_64_linux-5.14.0-124.el9.x86_64/ -j4`