### PR TITLE
issue #89: fix onload module file being removed during upgrades

### DIFF
--- a/scripts/onload_misc/openonload.spec
+++ b/scripts/onload_misc/openonload.spec
@@ -228,11 +228,13 @@ ldconfig -n /usr/lib /usr/lib64
 
 %postun
 
-if [ `cat /proc/1/comm` == systemd ]
-then
-  rm /usr/local/lib/modules-load.d/onload.conf
-else
-  rm /etc/sysconfig/modules/onload.modules
+# Remove these files only during uninstall, not during an upgrade
+if [ $1 == 0 ]; then
+  if [ `cat /proc/1/comm` == systemd ]; then
+    rm /usr/local/lib/modules-load.d/onload.conf
+  else
+    rm /etc/sysconfig/modules/onload.modules
+  fi
 fi
 
 ldconfig -n /usr/lib /usr/lib64


### PR DESCRIPTION
Fixes #89 

As specified in [Packaging-Guidelines](https://docs.fedoraproject.org/en-US/packaging-guidelines/Scriptlets/#_syntax) there should be a test wether it's a full-blown install/uninstall, or if it's a package upgrade.

I only added it on the post-uninstall sequence, as we still want to have the latest version of `/usr/share/onload/onload_modules-load.d.conf` to be propagated on the copied (untracked) file.