### PR TITLE
implement capability to disable netdriver build

### DIFF
--- a/mk/linux_kbuild.mk
+++ b/mk/linux_kbuild.mk
@@ -55,6 +55,13 @@ ifneq ($(HAVE_X3_NET),0)
  EXTRA_CFLAGS += -DCI_XLNX_EFCT_HEADER='"$(X3_NET_PATH)/include/$(X3_NET_HDR)"'
 endif
 
+HAVE_SFC ?= 1
+ifeq ($(HAVE_SFC),1)
+  EXTRA_CFLAGS += -DCI_HAVE_SFC=1
+else
+  EXTRA_CFLAGS += -DCI_HAVE_SFC=0
+endif
+
 TRANSPORT_CONFIG_OPT_HDR ?= ci/internal/transport_config_opt_extra.h
 EXTRA_CFLAGS += -DTRANSPORT_CONFIG_OPT_HDR='<$(TRANSPORT_CONFIG_OPT_HDR)>'
 

--- a/mk/site/mmake.mk
+++ b/mk/site/mmake.mk
@@ -5,6 +5,7 @@ AUX_BUS_PATH ?= $(TOPPATH)/../cns-auxiliary-bus
 HAVE_CNS_AUX := $(or $(and $(wildcard $(AUX_BUS_PATH)),1),0)
 X3_NET_PATH ?= $(TOPPATH)/../x3-net-linux
 HAVE_X3_NET := $(or $(and $(wildcard $(X3_NET_PATH)),1),0)
+HAVE_SFC ?= 1
 include $(BUILD)/config.mk
 include $(BUILDPATH)/options_config.mk
 include $(TOPPATH)/mk/before.mk

--- a/scripts/onload_install
+++ b/scripts/onload_install
@@ -45,6 +45,7 @@ usage() {
   err "  --listfiles                - Do not install; just list installed files"
   err "  --build-profile            - Specify a build profile"
   err "  --no-initramfs             - Do not update initramfs"
+  err "  --no-sfc                   - Do not install sfc module"
   err
   exit 1
 }
@@ -351,9 +352,11 @@ install_kernel_modules() {
     try [ -d "$d" ]
   fi
   try $docd "$TOP/build/$d/driver/linux"
-  install_f sfc_driverlink.ko "$i_kernelmodules/sfc_driverlink.ko"
-  install_f virtual_bus.ko "$i_kernelmodules/virtual_bus.ko"
-  install_f sfc.ko "$i_kernelmodules/sfc.ko"
+  if ! $nosfc; then
+    install_f sfc_driverlink.ko "$i_kernelmodules/sfc_driverlink.ko"
+    install_f virtual_bus.ko "$i_kernelmodules/virtual_bus.ko"
+    install_f sfc.ko "$i_kernelmodules/sfc.ko"
+  fi
   install_f sfc_resource.ko "$i_kernelmodules/sfc_resource.ko"
   install_f sfc_char.ko "$i_kernelmodules/sfc_char.ko"
   install_f onload.ko "$i_kernelmodules/onload.ko"
@@ -390,14 +393,17 @@ install_kernel_modules() {
 
   # Install driver meta-data.
   try $docd "$TOP/build/$d/driver"
-  install_f linux_net/drivers/net/ethernet/sfc/Module.symvers "$i_kernelmodules/sfc.symvers"
-  install_f linux_net/drivers/bus/Module.symvers "$i_kernelmodules/virtual_bus.symvers"
+  if ! $nosfc; then
+    install_f linux_net/drivers/net/ethernet/sfc/Module.symvers "$i_kernelmodules/sfc.symvers"
+    install_f linux_net/drivers/bus/Module.symvers "$i_kernelmodules/virtual_bus.symvers"
+
+    # Install driver headers
+    install_f linux_net/drivers/net/ethernet/sfc/driverlink_api.h "$i_kernelmodules/driverlink_api.h"
+    install_f linux_net/drivers/net/ethernet/sfc/filter.h "$i_kernelmodules/filter.h"
+  fi
   install_f linux_resource/Module.symvers "$i_kernelmodules/sfc_resource.symvers"
   install_f linux_char/Module.symvers "$i_kernelmodules/sfc_char.symvers"
   install_f linux_onload/Module.symvers "$i_kernelmodules/onload.symvers"
-  # Install driver headers
-  install_f linux_net/drivers/net/ethernet/sfc/driverlink_api.h "$i_kernelmodules/driverlink_api.h"
-  install_f linux_net/drivers/net/ethernet/sfc/filter.h "$i_kernelmodules/filter.h"
 }
 
 
@@ -649,6 +655,7 @@ devel=false
 # $debug_dir is relevant for blob binaries only.  We package debug and ndebug
 # versions, and need to select between them.
 debug_dir=
+nosfc=false
 
 sbindir="/sbin"
 usrdir="/usr"
@@ -714,6 +721,7 @@ while [ $# -gt 0 ]; do
   --lib32dir=*) lib32dir=${1#--lib32dir=};;
   --lib64dir=*) lib64dir=${1#--lib64dir=};;
   --kernelmodulesdir=*) kernelmodulesdir=${1#--kernelmodulesdir=};;
+  --no-sfc) nosfc=true;;
   -*)           usage;;
   *)            break;;
   esac

--- a/src/driver/linux_resource/mmake.mk
+++ b/src/driver/linux_resource/mmake.mk
@@ -9,12 +9,12 @@
 ############################
 
 RESOURCE_SRCS	:= resource_driver.c \
-	iopage.c driverlink_new.c kernel_proc.c filter.c \
+	iopage.c kernel_proc.c filter.c \
 	bt_stats.c compat_pat_wc.c port_sniff.c nondl_resource.c sysfs.c \
 	nondl_driver.c sfcaffinity.c nic_notifier.c \
 	aux_driver.c aux_efct.c efct_superbuf.c
 
-EFHW_SRCS	:= nic.c eventq.c ef10.c ef100.c af_xdp.c ethtool_rxclass.c \
+EFHW_SRCS	:= nic.c eventq.c af_xdp.c ethtool_rxclass.c \
 		ethtool_flow.c efct.c
 
 EFHW_HDRS	:= ef10_mcdi.h ethtool_rxclass.h ethtool_flow.h ef10_ef100.h \
@@ -43,6 +43,10 @@ EFRM_SRCS	:=			\
 EFRM_HDRS	:= efrm_internal.h efrm_vi.h efrm_vi_set.h \
 		efrm_pd.h efrm_pio.h bt_manager.h
 
+ifeq ($(HAVE_SFC),1)
+RESOURCE_SRCS += driverlink_new.c
+EFHW_SRCS += ef10.c ef100.c
+endif
 
 IMPORT		:= $(EFHW_SRCS:%=../../lib/efhw/%) \
 		   $(EFHW_HDRS:%=../../lib/efhw/%) \
@@ -65,7 +69,9 @@ arm64_TARGET_SRCS := syscall_aarch64.o
 # linux kbuild support
 #
 
+ifeq ($(HAVE_SFC),1)
 KBUILD_EXTRA_SYMBOLS := $(BUILDPATH)/driver/linux_net/drivers/net/ethernet/sfc/Module.symvers
+endif
 
 ifndef CONFIG_AUXILIARY_BUS
 ifneq ($(HAVE_CNS_AUX),0)

--- a/src/driver/linux_resource/resource_driver.c
+++ b/src/driver/linux_resource/resource_driver.c
@@ -419,7 +419,9 @@ efrm_nic_add(void *drv_device, struct device *dev,
 	lnic->drv_device = drv_device;
 	efrm_nic = &lnic->efrm_nic;
 	nic = &efrm_nic->efhw_nic;
+#if CI_HAVE_SFC
 	efrm_driverlink_resume(nic);
+#endif
 
 	if( timer_quantum_ns )
 		nic->timer_quantum_ns = timer_quantum_ns;
@@ -685,6 +687,7 @@ static int init_sfc_resource(void)
 	}
 	efrm_filter_install_proc_entries();
 
+#if CI_HAVE_SFC
 	/* Register the driver so that our 'probe' function is called for
 	 * each EtherFabric device in the system.
 	 */
@@ -693,6 +696,7 @@ static int init_sfc_resource(void)
 		EFRM_ERR("%s: no devices found", __func__);
 	if (rc < 0)
 		goto failed_driverlink;
+#endif
 
 	rc = efrm_auxbus_register();
 	if (rc < 0)
@@ -712,8 +716,10 @@ static int init_sfc_resource(void)
 	return 0;
 
 failed_auxbus:
+#if CI_HAVE_SFC
 	efrm_driverlink_unregister();
 failed_driverlink:
+#endif
 	efrm_filter_remove_proc_entries();
 	efrm_uninstall_proc_entries();
 	efrm_driver_stop();
@@ -742,9 +748,11 @@ static void cleanup_sfc_resource(void)
 	efrm_remove_sysfs_entries();
 	efrm_nondl_shutdown();
 	efrm_auxbus_unregister();
+#if CI_HAVE_SFC
 	/* Unregister from driverlink first, free
 	 * the per-NIC structures next. */
 	efrm_driverlink_unregister();
+#endif
 	efrm_nic_shutdown_all();
 	efrm_nic_del_all();
 

--- a/src/driver/mmake.mk
+++ b/src/driver/mmake.mk
@@ -10,7 +10,17 @@ MMAKE_NO_DEPS	:= 1
 ifeq ($(LINUX),1)
 
 # DRIVER_SUBDIRS must be ordered according to inter-driver dependencies
-DRIVER_SUBDIRS	:= linux_net linux_resource linux_char linux_onload linux
+
+# Always include linux_net when mmakebuildtree is running, to allow
+# user to switch sfc build at 'make' time.
+ifeq ($(MMAKEBUILDTREE),1)
+DRIVER_SUBDIRS  += linux_net
+else ifeq ($(HAVE_SFC),1)
+DRIVER_SUBDIRS  += linux_net
+else
+endif
+
+DRIVER_SUBDIRS	+= linux_resource linux_char linux_onload linux
 
 endif # ifeq ($(LINUX),1)
 

--- a/src/include/ci/efhw/af_xdp.h
+++ b/src/include/ci/efhw/af_xdp.h
@@ -21,4 +21,8 @@ extern struct efhw_func_ops af_xdp_char_functional_units;
 
 #endif
 
+#if !defined(EFHW_HAS_AF_XDP) && !CI_HAVE_SFC
+#error HAVE_SFC=0 build mode is unavailable since AF_XDP is not supported
+#endif
+
 #endif /* CI_EFHW_AF_XDP_H */

--- a/src/lib/efhw/nic.c
+++ b/src/lib/efhw/nic.c
@@ -180,6 +180,7 @@ void efhw_nic_init(struct efhw_nic *nic, unsigned flags, unsigned options,
 	spin_lock_init(&nic->pci_dev_lock);
 
 	switch (nic->devtype.arch) {
+#if CI_HAVE_SFC
 	case EFHW_ARCH_EF10:
 		nic->q_sizes[EFHW_EVQ] = 512 | 1024 | 2048 | 4096 | 8192 |
 			16384 | 32768;
@@ -238,6 +239,7 @@ void efhw_nic_init(struct efhw_nic *nic, unsigned flags, unsigned options,
 		nic->vi_shift = vi_shift;
 		nic->vi_stride = vi_stride;
 		break;
+#endif /* CI_HAVE_SFC */
 #ifdef EFHW_HAS_AF_XDP
 	case EFHW_ARCH_AF_XDP:
 		/* No restrictions on queue sizes */

--- a/src/lib/efrm/efrm_pio.c
+++ b/src/lib/efrm/efrm_pio.c
@@ -40,6 +40,17 @@
 #include "efrm_pio.h"
 #include "efrm_internal.h"
 
+#if ! CI_HAVE_SFC
+static int _dummy_ef10_nic_piobuf(struct efhw_nic *nic, ...)
+{
+	return -EOPNOTSUPP;
+}
+
+#define ef10_nic_piobuf_alloc _dummy_ef10_nic_piobuf
+#define ef10_nic_piobuf_free _dummy_ef10_nic_piobuf
+#define ef10_nic_piobuf_link _dummy_ef10_nic_piobuf
+#define ef10_nic_piobuf_unlink _dummy_ef10_nic_piobuf
+#endif /* ! CI_HAVE_SFC */
 
 #define efrm_pio(rs1)  container_of((rs1), struct efrm_pio, epio_rs)
 

--- a/src/lib/efrm/efrm_slice_ext.c
+++ b/src/lib/efrm/efrm_slice_ext.c
@@ -7,6 +7,19 @@
 #include <ci/efhw/ef100.h>
 #include "efrm_internal.h"
 
+#if ! CI_HAVE_SFC
+static int _dummy_ef100_nic_ext(struct efhw_nic *nic, ...)
+{
+	return -EOPNOTSUPP;
+}
+
+#define ef100_nic_ext_alloc _dummy_ef100_nic_ext
+#define ef100_nic_ext_free _dummy_ef100_nic_ext
+#define ef100_nic_ext_get_meta_global _dummy_ef100_nic_ext
+#define ef100_nic_ext_get_meta_msg _dummy_ef100_nic_ext
+#define ef100_nic_ext_msg _dummy_ef100_nic_ext
+#endif /* ! CI_HAVE_SFC */
+
 struct efrm_ext {
 	struct efrm_resource rs;
 	struct efrm_pd *pd;


### PR DESCRIPTION
Introduce the HAVE_SFC variable to control sfc/driverlink build.
If it is unset (default), disable build of the entire netdriver
and driverlink support, and also other code in sfc_resource module
which uses driverlink API:
- PIO support
- EF100 slice extensions support

It is useful to isolate netdriver and onload modules build to get an easier
way to add support of new kernel versions in case when sfc build is broken
on new kernels (5.18 for now). For AF_XDP we do not need sfc and driverlink,
so we may proceed with new kernel support avoiding netdriver issues.

---

**Testing done**
Onload works with Debian 5.18.0-2-amd64 in AF_XDP mode when building with `MMAKE_LIBERAL=1`. (despite a lot of warnings when building modules).