### PR TITLE
Fix 5.18 warnings

### DIFF
--- a/src/driver/linux_resource/kernel_proc.c
+++ b/src/driver/linux_resource/kernel_proc.c
@@ -99,8 +99,7 @@ efrm_proc_dir_get(char const* dirname, struct proc_dir_entry* parent,
 	
 	/* Does it already exist? If so, increment the refcount */
 	while ( procdir ) {
-		if ( procdir->efrm_pd_name
-		     && !strcmp(procdir->efrm_pd_name, dirname) ) {
+		if ( !strcmp(procdir->efrm_pd_name, dirname) ) {
 			procdir->efrm_pd_refcount++;
 			rval = procdir;
 			break;

--- a/src/include/ci/compat/utils.h
+++ b/src/include/ci/compat/utils.h
@@ -122,7 +122,7 @@
   sizeof(((c_type*)0)->mbr_name)
 
 #define __CI_CONTAINER(c_type, mbr_name, p_mbr)  \
-  ( (c_type*) ((char*)(p_mbr) - CI_MEMBER_OFFSET(c_type, mbr_name)) )
+  ( (c_type*) ((ci_uintptr_t)(p_mbr) - CI_MEMBER_OFFSET(c_type, mbr_name)) )
 
 #ifndef CI_CONTAINER
 # define CI_CONTAINER(t,m,p)  __CI_CONTAINER(t,m,p)

--- a/src/lib/efthrm/tcp_helper_endpoint_move.c
+++ b/src/lib/efthrm/tcp_helper_endpoint_move.c
@@ -197,6 +197,7 @@ static int efab_ip_queue_copy(ci_netif *ni_to, ci_ip_pkt_queue *q_to,
 {
   ci_ip_pkt_fmt *pkt_to, *pkt_from;
   oo_pkt_p pp;
+  size_t pkt_start_copy_offs = CI_MEMBER_OFFSET(ci_ip_pkt_fmt, pay_len);
 
   ci_ip_queue_init(q_to);
   if( q_from->num == 0 )
@@ -211,8 +212,9 @@ static int efab_ip_queue_copy(ci_netif *ni_to, ci_ip_pkt_queue *q_to,
       return -ENOBUFS;
     pkt_to->flags |= CI_PKT_FLAG_RX;
     ni_to->state->n_rx_pkts++;
-    memcpy(&pkt_to->pay_len, &pkt_from->pay_len,
-           CI_CFG_PKT_BUF_SIZE - CI_MEMBER_OFFSET(ci_ip_pkt_fmt, pay_len));
+    memcpy((void*)((ci_uintptr_t)pkt_to + pkt_start_copy_offs),
+           (void*)((ci_uintptr_t)pkt_from + pkt_start_copy_offs),
+           CI_CFG_PKT_BUF_SIZE - pkt_start_copy_offs);
     ci_ip_queue_enqueue(ni_to, q_to, pkt_to);
     pp = pkt_from->next;
   } while( OO_PP_NOT_NULL(pp) );

--- a/src/lib/transport/ip/netif_tx.c
+++ b/src/lib/transport/ip/netif_tx.c
@@ -229,6 +229,7 @@ void ci_netif_dmaq_shove2(ci_netif* ni, int intf_i, int is_fresh)
 }
 
 
+#if CI_CFG_TCP_OFFLOAD_RECYCLER
 void ci_netif_dmaq_shove_plugin(ci_netif* ni, int intf_i, int q_id)
 {
   ef_vi* vi = &ni->nic_hw[intf_i].vis[q_id];
@@ -237,6 +238,7 @@ void ci_netif_dmaq_shove_plugin(ci_netif* ni, int intf_i, int q_id)
     __ci_netif_dmaq_shove(ni, &ni->state->nic[intf_i].dmaq[q_id], vi, intf_i,
                           0 /*is_fresh*/);
 }
+#endif
 
 
 void __ci_netif_send(ci_netif* netif, ci_ip_pkt_fmt* pkt)

--- a/src/lib/transport/ip/netif_tx.h
+++ b/src/lib/transport/ip/netif_tx.h
@@ -281,11 +281,13 @@ extern void ci_netif_dmaq_shove1(ci_netif*, int intf_i);
  */
 extern void ci_netif_dmaq_shove2(ci_netif*, int intf_i, int is_fresh);
 
+#if CI_CFG_TCP_OFFLOAD_RECYCLER
 /* Moves packets from the non-first overflow queue (i.e. for communicating
  * with EF100 slice plugins) to the hardware ring if the hardware queue has at
  * least space for one packet.
  */
 void ci_netif_dmaq_shove_plugin(ci_netif* ni, int intf_i, int q_id);
+#endif
 
 
 #define ci_netif_dmaq(ni, nic_i)  (&(ni)->state->nic[nic_i].dmaq[0])

--- a/src/lib/transport/ip/socket.c
+++ b/src/lib/transport/ip/socket.c
@@ -50,8 +50,11 @@ void ci_sock_cmn_init(ci_netif* ni, ci_sock_cmn* s, int can_poison)
 {
   /* Poison. */
   CI_DEBUG(
-  if( can_poison )
-    memset(&s->b + 1, 0xf0, (char*) (s + 1) - (char*) (&s->b + 1));
+  if( can_poison ) {
+    ci_uintptr_t poison_start = (ci_uintptr_t)&s->b + sizeof(s->b);
+    size_t poison_len = (ci_uintptr_t)(s + 1) - poison_start;
+    memset((void*)poison_start, 0xf0, poison_len);
+  }
   )
 
   citp_waitable_reinit(ni, &s->b);

--- a/src/lib/transport/ip/tcp_init_shared.c
+++ b/src/lib/transport/ip/tcp_init_shared.c
@@ -276,9 +276,9 @@ void ci_tcp_state_init(ci_netif* netif, ci_tcp_state* ts, int from_cache)
 #if defined(TCP_STATE_POISON) && !defined(NDEBUG)
   /* Can't poison a cached socket - there's some bits of state to preserve. */
   if( !from_cache ) {
-    void *poison_start = &ts->s.b + 1;
-    memset(poison_start, TCP_STATE_POISON,
-           ((char*)(ts+1)) - (char*)poison_start);
+    ci_uintptr_t poison_start = (ci_uintptr_t)&ts->s.b + sizeof(ts->s.b);
+    size_t poison_len = (ci_uintptr_t)(ts + 1) - poison_start;
+    memset((void*)poison_start, TCP_STATE_POISON, poison_len);
   }
 #endif
 

--- a/src/lib/transport/ip/udp.c
+++ b/src/lib/transport/ip/udp.c
@@ -50,7 +50,12 @@ static void ci_udp_state_init(ci_netif* netif, ci_udp_state* us)
     us->s.cp.sock_cp_flags |= OO_SCP_NO_MULTICAST;
 
   /* Poison. */
-  CI_DEBUG(memset(&us->s + 1, 0xf0, (char*) (us + 1) - (char*) (&us->s + 1)));
+  CI_DEBUG(
+  {
+    ci_uintptr_t poison_start = (ci_uintptr_t)&us->s + sizeof(us->s);
+    size_t poison_len = (ci_uintptr_t)(us + 1) - poison_start;
+    memset((void*)poison_start, 0xf0, poison_len);
+  });
 
   /*! \todo This should be part of sock_cmn reinit, but the comment to that
    * function suggests that it's possibly not a good plan to move it there */


### PR DESCRIPTION
Fix compiler warnings appearing on 5.18 kernel.
See #95 

**Testing done:**
build drivers on Debian 5.18.0-4-amd64 with GCC 12.2.0.
`make -C build/x86_64_linux-5.18.0-4-amd64/ -j4 HAVE_SFC=0`
Socket Tester sanity all pass (was run on  Debian11 5.18.0-0.deb11.3-rt-amd64)