### PR TITLE
Improve build/install scripts for non-sfc case

### DIFF
--- a/scripts/onload_build
+++ b/scripts/onload_build
@@ -32,6 +32,8 @@ usage() {
   err "  --ppc-at <path>             - Path to IBM Advanced Toolchain install"
   fi
   err "  --build-profile             - Specify a build profile"
+  err "  --no-sfc                    - Do not build sfc module (pass HAVE_SFC=0"\
+                                       "to the build system)"
   err
   exit 1
 }
@@ -80,6 +82,7 @@ while [ $# -gt 0 ]; do
   --build-profile)   [ $# -gt 1 ] || usage; build_profile="$2"; shift;;
   --build-profile=*) build_profile=${1#--build-profile=};;
   --cc)  [ $# -gt 1 ] || usage; use_cc="CC=$2"; export use_cc; shift;;
+  --no-sfc)     export HAVE_SFC=0;;
   -*)           usage;;
   *)            break;;
   esac

--- a/scripts/onload_install
+++ b/scripts/onload_install
@@ -764,6 +764,10 @@ if $build; then
     logprog "Using IBM Advanced Toolchain at $ppc_at"
     buildargs="$buildargs --ppc-at $ppc_at"
   fi
+  if $nosfc; then
+    logprog "Building Onload without sfc driver"
+    buildargs="$buildargs --no-sfc"
+  fi
   logprog "Building Onload."
   "$bin/onload_build" $buildargs ||
     fail "ERROR: Build failed.  Not installing."


### PR DESCRIPTION
Improve `onload_build` and `onload_install` scripts for non-sfc case - make them more convenient for a user.

---
**Testing**
System: Debian 5.18.0-4-amd64
Command line:
```shell
$ sudo ./scripts/onload_install --no-sfc
onload_install: Building Onload without sfc driver
onload_install: Building Onload.
....
$ sudo onload_tool reload --onload-only                                                                                           
onload_tool: /sbin/modprobe onload                                                                                                                                                                                 
$ lsmod | grep sfc
sfc_char              131072  1 onload
sfc_resource          159744  2 onload,sfc_char
```