### PR TITLE
issue #95: af_xdp: remove use of bpf_op_t

### DIFF
--- a/src/lib/efhw/af_xdp.c
+++ b/src/lib/efhw/af_xdp.c
@@ -439,16 +439,17 @@ static int xdp_bind(struct socket* sock, int ifindex, unsigned queue, unsigned f
 /* Link an XDP program to an interface */
 static int xdp_set_link(struct net_device* dev, struct bpf_prog* prog)
 {
-  bpf_op_t op = dev->netdev_ops->ndo_bpf;
   struct netdev_bpf bpf = {
     .command = XDP_SETUP_PROG,
     .prog = prog
   };
 
-  if( !op )
+  if( !dev->netdev_ops->ndo_bpf ) {
     EFHW_ERR("%s: %s does not support XDP", __FUNCTION__, dev->name);
+    return -ENOSYS;
+  }
 
-  return op ? op(dev, &bpf) : -ENOSYS;
+  return dev->netdev_ops->ndo_bpf(dev, &bpf);
 }
 
 /* Fault handler to provide buffer memory pages for our user mapping */


### PR DESCRIPTION
In Linux 5.19 the `bpf_op_t` is moved into private code and it is not available for modules anymore.
See kernel commit 6264f58ca0e54e41d63c2d00334a48bac28fbf30 which introduces the breakage.

---
Tested by building modules on CentOS 8  with kernels:
- 5.19.1-1.el8.elrepo.x86_64
- 5.16.13-1.el8.elrepo.x86_64

Both are ok.