### PR TITLE
gcc-12: fix segfault when executing library

### DIFF
--- a/src/include/onload/version.h
+++ b/src/include/onload/version.h
@@ -15,11 +15,7 @@
 #define __ONLOAD_VERSION_H__
 
 
-/* onload_version and onload_version_private are the same data, but _private
- * is not exported so can't be overridden by the dynamic linker so has the
- * correct value at early startup */
 extern const char* onload_version;
-extern const char onload_version_private[];
 extern const char onload_short_version[];
 extern const char onload_product[];
 extern const char onload_copyright[];

--- a/src/lib/cplane/onload_version.c
+++ b/src/lib/cplane/onload_version.c
@@ -8,5 +8,4 @@
 const char onload_product[] = ONLOAD_PRODUCT;
 const char onload_copyright[] = ONLOAD_COPYRIGHT;
 const char* const onload_version = ONLOAD_VERSION;
-const char onload_version_private[] = ONLOAD_VERSION;
 const char onload_short_version[] = ONLOAD_SHORT_VERSION;


### PR DESCRIPTION
When the library is run as an executable, new gcc-12 results in segfault. Simplify the code in onload_version_msg(), so that it works seamlessly.

Avoid local_strlen(), because it results in strlen() call in any way (when using gcc-12).
Additionally, msg0 was not initialized properly with gcc-12, and I failed to understand why.  Given that local_strlen() is harmful now, I did not explore it further.

-------
**Tested** on Debian testing with gcc-12.
before the patch:
```
bash$ $ONLOAD_PRELOAD 
Segmentation fault (core dumped)
```
after the patch:
```
bash$ $ONLOAD_PRELOAD 
Onload 79181116e7 2022-10-06 segfault-gcc-12 
Copyright 2019-2022 Xilinx, 2006-2019 Solarflare Communications, 2002-2005 Level 5 Networks
Built: Oct  6 2022 16:10:19 (debug)
Build profile header: <ci/internal/transport_config_opt_extra.h>
```