### PR TITLE
icmp: fix UBSAN warning about array idx=-1

### DIFF
--- a/src/lib/efthrm/ip_protocols.c
+++ b/src/lib/efthrm/ip_protocols.c
@@ -226,7 +226,7 @@ ci_ipp_pmtu_rx(ci_netif *netif, ci_pmtu_state_t *pmtus,
     ipx = (ci_ipx_hdr_t*)(&tb[1]);
     len = ipx_hdr_tot_len(ipx_hdr_af(ipx), ipx);
     ctr = CI_PMTU_PLATEAU_ENTRY_MAX;
-    while( ctr >= 0 && len <= plateau[ctr] )
+    while( ctr > 0 && len <= plateau[ctr] )
       --ctr;
     DEBUGPMTU(ci_log("%s: (legacy icmp) pmtu=%u(%d) ip_tot_len=%d",
 	             __FUNCTION__, plateau[ctr], ctr, len));


### PR DESCRIPTION
Tested with Socket Tester.  `sockapi-ts/attacks/icmp/tcp_break:env=VAR.env.peer2peer,type=3,code=4` complains in following way without this patch:
```
[21538.365769] ================================================================================
[21538.377860] UBSAN: array-index-out-of-bounds in /home/sasha/work/level5/onload/build/x86_64_linux-5.15.0-50-generic/driver/linux_onload/ip_protocols.c:232:36
[21538.401253] index -1 is out of range for type 'ci_uint16 [10]'
[21538.411392] CPU: 2 PID: 160 Comm: kworker/u17:0 Tainted: G           OE     5.15.0-50-generic #56~20.04.1-Ubuntu
[21538.427292] Hardware name: Dell Inc. PowerEdge R220/05Y15N, BIOS 1.4.0 10/23/2014
[21538.440103] Workqueue: onload-wq:0 tcp_helper_do_non_atomic [onload]
[21538.451742] Call Trace:
[21538.458824]  <TASK>
[21538.465421]  dump_stack_lvl+0x4a/0x63
[21538.473800]  dump_stack+0x10/0x16
[21538.481752]  ubsan_epilogue+0x9/0x49
[21538.489990]  __ubsan_handle_out_of_bounds.cold+0x44/0x49
[21538.500225]  oo_icmp_handle+0x163f/0x1810 [onload]
[21538.509924]  ? update_load_avg+0x7c/0x650
[21538.518636]  efab_tcp_helper_netif_lock_callback+0x7f6/0x1000 [onload]
[21538.530212]  efab_eplock_unlock_and_wake+0x8e/0x160 [onload]
[21538.540713]  efab_tcp_helper_netif_unlock+0x64/0x100 [onload]
[21538.551223]  tcp_helper_do_non_atomic+0x3e1/0x7e0 [onload]
[21538.561496]  process_one_work+0x22b/0x3d0
[21538.568943]  worker_thread+0x4d/0x3f0
[21538.576114]  ? process_one_work+0x3d0/0x3d0
[21538.584327]  kthread+0x12a/0x150
[21538.592012]  ? set_kthread_struct+0x50/0x50
[21538.600706]  ret_from_fork+0x22/0x30
[21538.608635]  </TASK>
[21538.614910] ================================================================================
```

With the patch there is no UBSAN complaint and the test is green.