### PR TITLE
Compat for Linux 6.0

### DIFF
--- a/src/driver/linux_resource/kernel_compat.sh
+++ b/src/driver/linux_resource/kernel_compat.sh
@@ -142,8 +142,6 @@ EFRM_HAS_FLUSH_DELAYED_FPUT	export	flush_delayed_fput	include/linux/file.h	fs/fi
 
 EFRM_IRQ_FREE_RETURNS_NAME	symtype	free_irq	include/linux/interrupt.h void *(unsigned int, void *)
 
-EFRM_HAS_ITER_TYPE	memtype	struct_iov_iter	iter_type	include/linux/uio.h	u8
-
 EFRM_HAS_LINUX_STDARG_H			file	include/linux/stdarg.h
 EFRM_HAS_AUXBUS_H			file	include/linux/auxiliary_bus.h
 EFRM_HAS_MOD_DT_AUXBUS_H		file	include/linux/mod_devicetable_auxiliary.h

--- a/src/driver/linux_resource/kernel_compat.sh
+++ b/src/driver/linux_resource/kernel_compat.sh
@@ -152,6 +152,7 @@ EFRM_HAVE_LOWCASE_PDE_DATA symbol pde_data include/linux/proc_fs.h
 EFRM_HAVE_NETIF_RX_NI symbol netif_rx_ni include/linux/netdevice.h
 
 EFRM_HAVE_MODULE_MUTEX		symbol	module_mutex	include/linux/module.h
+EFRM_HAVE_ITER_UBUF symbol ITER_UBUF include/linux/uio.h
 # TODO move onload-related stuff from net kernel_compat
 " | egrep -v -e '^#' -e '^$' | sed 's/[ \t][ \t]*/:/g'
 }

--- a/src/lib/efthrm/tcp_helper_linux.c
+++ b/src/lib/efthrm/tcp_helper_linux.c
@@ -31,16 +31,11 @@
 #ifdef EFRM_HAVE_FOP_READ_ITER
 /* linux >= 3.16 */
 
-#ifndef EFRM_HAS_ITER_TYPE
-/* linux < 5.14 */
-#define iter_type type
-#endif
-
 #define DEFINE_FOP_RW_ITER(base_handler, rw_iter_handler) \
   static ssize_t rw_iter_handler(struct kiocb *iocb, struct iov_iter *v)    \
   { if (!is_sync_kiocb(iocb))                                               \
       return -EOPNOTSUPP;                                                   \
-    if( ~v->iter_type & ITER_IOVEC )                                             \
+    if( !iter_is_iovec(v) )                                                 \
       return -EOPNOTSUPP;                                                   \
     return base_handler(iocb->ki_filp, v->iov, v->nr_segs); }
 #else

--- a/src/lib/efthrm/tcp_helper_linux.c
+++ b/src/lib/efthrm/tcp_helper_linux.c
@@ -31,13 +31,43 @@
 #ifdef EFRM_HAVE_FOP_READ_ITER
 /* linux >= 3.16 */
 
+#ifdef EFRM_HAVE_ITER_UBUF
+/* linux >= 6.0
+ * See kernel commits
+ * fcb14cb1bdacec5b4374fe161e83fb8208164a85
+ * and
+ * 3e20a751aff0e099cff496511fef8cdf655b3360 */
+
+#define iov_iter_type_supported user_backed_iter
+
+#define FOP_RW_ITER_CALL_BASE_HANDLER(base_handler, iocb, iter)         \
+  do {                                                                  \
+    if( iter_is_ubuf(v) ) {                                             \
+      struct iovec iov = { .iov_base = v->ubuf, .iov_len = v->count };  \
+      return base_handler(iocb->ki_filp, &iov, 1);                      \
+    }                                                                   \
+    return base_handler(iocb->ki_filp, v->iov, v->nr_segs);             \
+  } while (0);
+
+#else
+
+#define iov_iter_type_supported iter_is_iovec
+
+#define FOP_RW_ITER_CALL_BASE_HANDLER(base_handler, iocb, iter)         \
+  do {                                                                  \
+    return base_handler(iocb->ki_filp, v->iov, v->nr_segs);             \
+  } while (0);
+
+#endif /* EFRM_HAVE_ITER_UBUF */
+
 #define DEFINE_FOP_RW_ITER(base_handler, rw_iter_handler) \
   static ssize_t rw_iter_handler(struct kiocb *iocb, struct iov_iter *v)    \
   { if (!is_sync_kiocb(iocb))                                               \
       return -EOPNOTSUPP;                                                   \
-    if( !iter_is_iovec(v) )                                                 \
+    if( !iov_iter_type_supported(v) )                                       \
       return -EOPNOTSUPP;                                                   \
-    return base_handler(iocb->ki_filp, v->iov, v->nr_segs); }
+    FOP_RW_ITER_CALL_BASE_HANDLER(base_handler, iocb, v); }
+
 #else
 
 #define DEFINE_FOP_READ(base_handler, rw_handler) \


### PR DESCRIPTION
Fix `struct iov_iter` processing in `f_ops->read_iter()` handler.
New 6.0 Linux changed the way it initializes `struct iov_iter` when passing it to read_iter().

**Testing**:
Onload build passes on CentOS 8: kernels `6.0.7-1.el8.elrepo.x86_64` and `4.18.0-408.el8.x86_64` both DEBUG and NDEBUG

Run socket tester test which calls read() from libc:
`--ool=socket_cache --ool=onload --tester-run=sockapi-ts/level5/fd_caching/fd_cache_nonblock_sync:env=VAR.env.peer2peer_two_iut,check_first=FALSE,nonblock_first=TRUE,nonblock_func=fcntl,func=read`
The test is green.
Before the patch it failed with ci_assert on 6.0:
```
[  629.748359] [onload] FAIL at /var/tmp/dnman/onload/src/include/ci/tools/iovec.h:34
[  629.756430] [onload] ci_assert(iovlen > 0)
[  629.756430] from /var/tmp/dnman/onload/src/include/ci/tools/iovec.h:34
```