### PR TITLE
newdriver build: fix -j option for ciul library

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,6 +83,7 @@ mkdirs:
 # Define the high-level dependencies between libraries:
 $(obj)/src/driver/linux_resource: $(AUTOCOMPAT) mkdirs
 $(obj)/src/lib/transport/ip: $(AUTOCOMPAT)
+$(obj)/src/lib/ciul: $(AUTOCOMPAT)
 $(obj)/src/lib/citools: $(AUTOCOMPAT)
 $(obj)/src/lib/cplane: $(AUTOCOMPAT) $(obj)/src/lib/ciul
 $(obj)/src/driver/linux_char: $(AUTOCOMPAT)


### PR DESCRIPTION
ciul library depends on autocompat.h, and Makefile should know it.

----
Fixes #110