### PR TITLE
Fix modules build on Linux 6.1 

### DIFF
--- a/mk/platform/linux.mk
+++ b/mk/platform/linux.mk
@@ -7,7 +7,7 @@ endif
 
 LINUX		   := 1
 
-LINUX_VERSION_3	   := $(shell cat $(KPATH)/include/{linux/utsrelease.h,generated/utsrelease.h,linux/version.h} 2>/dev/null | sed 's/^\#define UTS_RELEASE \"\([0-9]\+\.[0-9]\+\.[0-9]\+\).*/\1/; t; d')
+LINUX_VERSION_3	   := $(shell cat $(KPATH)/include/generated/utsrelease.h 2>/dev/null | sed 's/^\#define UTS_RELEASE \"\([0-9]\+\.[0-9]\+\.[0-9]\+\).*/\1/; t; d')
 
 DRIVER		   := 1
 MMAKE_USE_KBUILD   := 1

--- a/mk/platform/linux.mk
+++ b/mk/platform/linux.mk
@@ -35,3 +35,14 @@ endif
 MMAKE_KBUILD_ARGS_CONST := -C $(KPATH) NDEBUG=$(NDEBUG) GCOV=$(GCOV) CC=$(CC)
 MMAKE_KBUILD_ARGS = $(MMAKE_KBUILD_ARGS_CONST) $(MMAKE_KBUILD_ARGS_DBG)
 
+# Print the greatest version number from $(1) and $(2).
+greater_version = $(shell printf "$(1)\n$(2)\n" | sort --version-sort | tail -1)
+
+# To build library in kbuild with Linux >= 6.1, we must pass its path as a
+# target to make.
+# This approach does not work on Linux < 5.4, so in order not to break old
+# kernels, do it only with Linux >= 6.0.
+KBUILD_LIB_MAKE_TRG ?=
+ifeq ($(call greater_version,$(LINUX_VERSION_3),6.0), $(LINUX_VERSION_3))
+KBUILD_LIB_MAKE_TRG += $(lib_obj_path)
+endif

--- a/src/lib/citools/mmake.mk
+++ b/src/lib/citools/mmake.mk
@@ -85,7 +85,7 @@ lib_obj_path = $(BUILDPATH)/lib/citools
 
 lib_obj_cmd = $(LD) -r $(LIB_SRCS:%.c=%.o) -o $(lib_obj)
 all:
-	$(MAKE) $(MMAKE_KBUILD_ARGS) KBUILD_BUILTIN=1 KBUILD_EXTMOD=$(lib_obj_path)
+	$(MAKE) $(MMAKE_KBUILD_ARGS) KBUILD_BUILTIN=1 KBUILD_EXTMOD=$(lib_obj_path) $(KBUILD_LIB_MAKE_TRG)
 	$(lib_obj_cmd)
 	echo "cmd_$(lib_obj_path)/$(lib_obj) := $(lib_obj_cmd)" > .$(lib_obj).cmd
 

--- a/src/lib/ciul/mmake.mk
+++ b/src/lib/ciul/mmake.mk
@@ -155,7 +155,7 @@ lib_obj_path = $(BUILDPATH)/lib/ciul
 
 lib_obj_cmd = $(LD) -r $(LIB_SRCS:%.c=%.o) -o $(lib_obj)
 all:
-	$(MAKE) $(MMAKE_KBUILD_ARGS) KBUILD_BUILTIN=1 KBUILD_EXTMOD=$(lib_obj_path)
+	$(MAKE) $(MMAKE_KBUILD_ARGS) KBUILD_BUILTIN=1 KBUILD_EXTMOD=$(lib_obj_path) $(KBUILD_LIB_MAKE_TRG)
 	$(lib_obj_cmd)
 	echo "cmd_$(lib_obj_path)/$(lib_obj) := $(lib_obj_cmd)" > .$(lib_obj).cmd
 clean:

--- a/src/lib/cplane/mmake.mk
+++ b/src/lib/cplane/mmake.mk
@@ -43,7 +43,7 @@ lib_obj_path = $(BUILDPATH)/lib/cplane
 
 lib_obj_cmd = $(LD) -r $(LIB_SRCS:%.c=%.o) -o $(lib_obj)
 all: $(CP_INTF_VER_HDR)
-	$(MAKE) $(MMAKE_KBUILD_ARGS) KBUILD_BUILTIN=1 KBUILD_EXTMOD=$(lib_obj_path)
+	$(MAKE) $(MMAKE_KBUILD_ARGS) KBUILD_BUILTIN=1 KBUILD_EXTMOD=$(lib_obj_path) $(KBUILD_LIB_MAKE_TRG)
 	$(lib_obj_cmd)
 	echo "cmd_$(lib_obj_path)/$(lib_obj) := $(lib_obj_cmd)" > .$(lib_obj).cmd
 clean:

--- a/src/lib/transport/ip/mmake.mk
+++ b/src/lib/transport/ip/mmake.mk
@@ -157,7 +157,7 @@ lib_obj_path = $(BUILDPATH)/lib/transport/ip
 
 lib_obj_cmd = $(LD) -r $(LIB_SRCS:%.c=%.o) -o $(lib_obj)
 all:
-	$(MAKE) $(MMAKE_KBUILD_ARGS) KBUILD_BUILTIN=1 KBUILD_EXTMOD=$(lib_obj_path)
+	$(MAKE) $(MMAKE_KBUILD_ARGS) KBUILD_BUILTIN=1 KBUILD_EXTMOD=$(lib_obj_path) $(KBUILD_LIB_MAKE_TRG)
 	$(lib_obj_cmd)
 	echo "cmd_$(lib_obj_path)/$(lib_obj) := $(lib_obj_cmd)" > .$(lib_obj).cmd
 clean:


### PR DESCRIPTION
The fix for #114 

---
Testing:
Build on Debian11 with `6.1.0-rc3` passes.
```
mmakebuildtree --driver && make -C build/x86_64_linux-6.1.0-rc3/ HAVE_SFC=0 
```

Run Socket Tester `usecases/send_recv` test. All iterations pass.