### PR TITLE
makefile: fix --newdriver build with HAVE_SFC=0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -183,7 +183,7 @@ endif
 
 kernel: modules
 	@mkdir -p $(KBUILDTOP)/driver/linux
-	$(Q)ln -rsf $(KBUILDTOP)/src/driver/linux_onload/*.ko $(KBUILDTOP)/src/driver/linux_char/*.ko $(KBUILDTOP)/src/driver/linux_resource/*.ko $(KBUILDTOP)/src/driver/linux_net/drivers/net/ethernet/sfc/*.ko $(KBUILDTOP)/driver/linux
+	$(Q)ln -rsf $(wildcard $(patsubst %,$(KBUILDTOP)/%/*.ko,$(DRIVER_SUBDIRS))) $(KBUILDTOP)/driver/linux
 	$(Q)cp src/driver/linux/*.sh $(KBUILDTOP)/driver/linux
 
 modules modules_install: $(OUTMAKEFILES)


### PR DESCRIPTION
Do not try to create symlink for a module that was not built.

Fixes: f428e7470189 ("implement capability to disable netdriver build")

---

Building with sfc:
```
$ mmakebuildtree --newdriver
$ make -j4 -C build/x86_64_linux-5.10.0-19-amd64/
$ ls -l build/x86_64_linux-5.10.0-19-amd64/driver/linux/
total 40
-rwxr-xr-x 1 nikitins oktetlabs 20994 Nov 23 19:20 load.sh
lrwxrwxrwx 1 nikitins oktetlabs    39 Nov 23 19:20 onload.ko -> ../../src/driver/linux_onload/onload.ko
lrwxrwxrwx 1 nikitins oktetlabs    39 Nov 23 19:20 sfc_char.ko -> ../../src/driver/linux_char/sfc_char.ko
lrwxrwxrwx 1 nikitins oktetlabs    69 Nov 23 19:20 sfc_driverlink.ko -> ../../src/driver/linux_net/drivers/net/ethernet/sfc/sfc_driverlink.ko
lrwxrwxrwx 1 nikitins oktetlabs    58 Nov 23 19:20 sfc.ko -> ../../src/driver/linux_net/drivers/net/ethernet/sfc/sfc.ko
lrwxrwxrwx 1 nikitins oktetlabs    47 Nov 23 19:20 sfc_resource.ko -> ../../src/driver/linux_resource/sfc_resource.ko
-rw-r--r-- 1 nikitins oktetlabs  1986 Nov 23 19:20 shared.sh
-rwxr-xr-x 1 nikitins oktetlabs  4649 Nov 23 19:20 unload.sh
```

Building without sfc (before the patch there was also created weird *.ko symlink `'*.ko' -> '../../src/driver/linux_net/drivers/net/ethernet/sfc/*.ko'`):
```
$ mmakebuildtree --newdriver
$ make -j4 -C build/x86_64_linux-5.10.0-19-amd64/ HAVE_SFC=0
$ ls -l build/x86_64_linux-5.10.0-19-amd64/driver/linux/
total 36
-rwxr-xr-x 1 nikitins oktetlabs 20994 Nov 23 19:18 load.sh
lrwxrwxrwx 1 nikitins oktetlabs    39 Nov 23 19:18 onload.ko -> ../../src/driver/linux_onload/onload.ko
lrwxrwxrwx 1 nikitins oktetlabs    39 Nov 23 19:18 sfc_char.ko -> ../../src/driver/linux_char/sfc_char.ko
lrwxrwxrwx 1 nikitins oktetlabs    47 Nov 23 19:18 sfc_resource.ko -> ../../src/driver/linux_resource/sfc_resource.ko
-rw-r--r-- 1 nikitins oktetlabs  1986 Nov 23 19:18 shared.sh
-rwxr-xr-x 1 nikitins oktetlabs  4649 Nov 23 19:18 unload.sh
```
@rhughes-xilinx
