### PR TITLE
af_xdp: re-enable AF_XDP stacks

### DIFF
--- a/src/lib/efhw/af_xdp.c
+++ b/src/lib/efhw/af_xdp.c
@@ -1045,7 +1045,8 @@ static bool af_xdp_accept_vi_constraints(struct efhw_nic *nic, int low,
 					 unsigned order, void* arg)
 {
 	struct efhw_vi_constraints *avc = arg;
-	return avc->channel == low;
+	/* The only constrain is "no RSS, no sets". */
+	return avc->min_vis_in_set == 1 && avc->has_rss_context == 0;
 }
 
 /*--------------------------------------------------------------------


### PR DESCRIPTION
Fixes: cf9a523901 ("ON-14118: Move accept_vi_constraints to efhw hal.")

Fixes #115 .
`sudo onload nc -l 12345` does not fail any more.