### PR TITLE
udp_recv: Return real length if MSG_TRUNC is set in flags

### DIFF
--- a/src/lib/transport/ip/udp_recv.c
+++ b/src/lib/transport/ip/udp_recv.c
@@ -360,8 +360,12 @@ static int ci_udp_recvmsg_get(ci_udp_recv_info* rinf, ci_iovec_ptr* piov)
 
   if(CI_LIKELY( rc >= 0 )) {
 #if HAVE_MSG_FLAGS
-    if(CI_UNLIKELY( rc < pkt->pf.udp.pay_len && msg != NULL ))
-      rinf->msg_flags |= LOCAL_MSG_TRUNC;
+    if(CI_UNLIKELY( rc < pkt->pf.udp.pay_len )) {
+      if( msg != NULL )
+        rinf->msg_flags |= LOCAL_MSG_TRUNC;
+      if( rinf->flags & MSG_TRUNC )
+        rc = pkt->pf.udp.pay_len;
+    }
 #endif
     ci_udp_recvmsg_fill_msghdr(ni, msg, pkt, &us->s);
     if( ! (rinf->flags & MSG_PEEK) ) {


### PR DESCRIPTION
In man recv(2):
```
  MSG_TRUNC (since Linux 2.2)
    For raw (AF_PACKET), Internet datagram [...] sockets: return
    the real length of the packet or datagram, even when it was
    longer than the passed buffer.
```


This behavior is missing in onload prior to this patch, and onload would rather return the truncated size of the buffer, if the packet is larger than the provided buffer.

Note that TCP is unaffected by this and has a different behavior for MSG_TRUNC.

I tested with this test case:
```C
// Copyright 2022 Google LLC.
// SPDX-License-Identifier: Apache-2.0

#include <assert.h>
#include <errno.h>
#include <error.h>
#include <netinet/in.h>
#include <stddef.h>
#include <stdio.h>
#include <sys/socket.h>

int main(void) {
  struct sockaddr_in6 sin = {
    .sin6_family = PF_INET6,
    .sin6_addr = in6addr_any,
    .sin6_port = htons(12345),
  };
  char buf[2];
  int fd, ret;

  fd = socket(AF_INET6, SOCK_DGRAM, 0);
  if( fd < 0 )
    error(1, errno, "socket");

  ret = bind(fd, (struct sockaddr *)&sin, sizeof(sin));
  if( ret < 0 )
    error(1, errno, "bind");

  ret = recv(fd, NULL, 0, MSG_TRUNC);
  if( ret < 0 )
    error(1, errno, "recv 0");
  if( ret != 7 )
    error(1, 0, "recv 0: Expected 7, got %d", ret);

  ret = recv(fd, &buf, 1, MSG_TRUNC);
  if( ret < 0 )
    error(1, errno, "recv 1");
  if( ret != 7 )
    error(1, 0, "recv 1: Expected 7, got %d", ret);

  ret = recv(fd, &buf, 2, MSG_TRUNC);
  if( ret < 0 )
    error(1, errno, "recv 2");
  if( ret != 7 )
    error(1, 0, "recv 2: Expected 7, got %d", ret);

  puts("Success");
  return 0;
}
```

On a peer I run `echo -n abcdefg > /dev/udp/2002:a05:7101:5915::/12345` 3 times.

With Linux kernel networking stack I get:
```
# ./test
Success
```

With onload, without this patch:
```
# LD_PRELOAD="onload/build/gnu_/lib/transport/unix/libcitransport0.so" ./test
onload: WARNING: EF_TCP_SYNRECV_MAX=16384 and EF_MAX_ENDPOINTS=8192 are inconsistent.
onload: EF_TCP_SYNRECV_MAX is set to 16384 based on /proc/sys/net/ipv4/tcp_max_syn_backlog value and assuming up to 4 listening sockets in the Onload stack
onload: Too few endpoints requested: ~4 syn-receive states consume one endpoint. 
oo:test[91245]: Using Onload 2e9f5309 2022-12-13 cloud [0]
oo:test[91245]: Copyright 2019-2022 Xilinx, 2006-2019 Solarflare Communications, 2002-2005 Level 5 Networks
./test: recv 0: Expected 7, got 0
```

With onload, with this patch:
```
# LD_PRELOAD="onload/build/gnu_/lib/transport/unix/libcitransport0.so" ./test
onload: WARNING: EF_TCP_SYNRECV_MAX=16384 and EF_MAX_ENDPOINTS=8192 are inconsistent.
onload: EF_TCP_SYNRECV_MAX is set to 16384 based on /proc/sys/net/ipv4/tcp_max_syn_backlog value and assuming up to 4 listening sockets in the Onload stack
onload: Too few endpoints requested: ~4 syn-receive states consume one endpoint. 
oo:test[89574]: Using Onload 2e9f5309 2022-12-13 cloud [3]
oo:test[89574]: Copyright 2019-2022 Xilinx, 2006-2019 Solarflare Communications, 2002-2005 Level 5 Networks
Success
```
