### PR TITLE
Purge challenge_ack_limit, following linux-6.0

### DIFF
--- a/src/include/ci/internal/ip_shared_types.h
+++ b/src/include/ci/internal/ip_shared_types.h
@@ -739,12 +739,9 @@ typedef struct {
   ci_iptime_t tconst_pmtu_discover_recover;
 #define CI_PMTU_TCONST_DISCOVER_RECOVER (30*1000)
 
-  /* RFC 5961: limit for challenge ack packets per tick,
-   * derived from NI_OPTS(netif).challenge_ack_limit. */
-  ci_uint32 tconst_challenge_ack_limit;
-
   /* Rate limit for ACKs sent in response to invalid TCP packets,
-   * time period in ticks. */
+   * time period in ticks.
+   * It is used to limit challenge ACKs from RFC 5961 as well. */
   ci_iptime_t tconst_invalid_ack_ratelimit;
 
   /* Maximum time to defer a packet with unresolved MAC. */
@@ -1297,10 +1294,6 @@ struct ci_netif_state_s {
 
   /* List of sockets that may have reapable buffers. */
   struct oo_p_dllink        reap_list;
-
-  /* RFC 5961: limit the number of challenge ACKs */
-  ci_uint32     challenge_ack_num;
-  ci_iptime_t   challenge_ack_time;
 
 #if CI_CFG_SUPPORT_STATS_COLLECTION
   ci_int32              stats_fmt; /**< Output format */

--- a/src/include/ci/internal/opts_netif_def.h
+++ b/src/include/ci/internal/opts_netif_def.h
@@ -854,14 +854,6 @@ CI_CFG_OPT("EF_DYNAMIC_ACK_THRESH", dynack_thresh, ci_uint16,
            , , 16, 0, 65535, count)
 #endif
 
-CI_CFG_OPT("EF_CHALLENGE_ACK_LIMIT", challenge_ack_limit,
-           ci_uint32,
-"Limit the number of \"challenge ACK packets\" sent as part of TCP blind "
-"window attack mitigation, RFC 5961; in packets per second.  "
-"The limitation applies for each Onload stack separately.\n"
-"The value from /proc/sys/net/ipv4/tcp_challenge_ack_limit is used by default.",
-          , , CI_CFG_CHALLENGE_ACK_LIMIT, 0, 65535, count)
-
 CI_CFG_OPT("EF_INVALID_ACK_RATELIMIT", oow_ack_ratelimit, ci_uint32,
 "Limit the rate of ACKs sent because of invalid incoming TCP packet, "
 "in milliseconds.  The limitation is applied per-socket.  "

--- a/src/include/ci/internal/stats_def.h
+++ b/src/include/ci/internal/stats_def.h
@@ -484,8 +484,6 @@ OO_STAT("Number of challenge ACKs sent (RFC 5961).",
 OO_STAT("Number of challenge ACKs not sent because of packet allocation "
         "failure.",
         ci_uint32, challenge_ack_out_of_pkts, count)
-OO_STAT("Number of challenge ACKs not sent because of rate-limiting.",
-        ci_uint32, challenge_ack_limited, count)
 OO_STAT("Number of deferred packets when next hop MAC address is not known.",
         ci_uint32, tx_defer_pkt, count)
 OO_STAT("Number of deferred packets sent without any real delay.",

--- a/src/include/ci/internal/transport_config_opt.h
+++ b/src/include/ci/internal/transport_config_opt.h
@@ -316,10 +316,6 @@
  * Default value for EF_TCP_TIME_WAIT_ASSASSINATION. */
 #define CI_CFG_TIME_WAIT_ASSASSINATE 1
 
-/* Default challenge ACK limitation (in count per second),
- * same as of linux-4.19 */
-#define CI_CFG_CHALLENGE_ACK_LIMIT 1000
-
 /* Default ACK limitation when sending respnse to invalid packet,
  * in ms, same as of linux-4.19 */
 #define CI_CFG_TCP_OUT_OF_WINDOW_ACK_RATELIMIT 500

--- a/src/lib/transport/ip/netif_debug.c
+++ b/src/lib/transport/ip/netif_debug.c
@@ -696,9 +696,6 @@ void ci_stack_time_dump(ci_netif* ni, oo_dump_log_fn_t logger, void* log_arg)
             NI_CONF(ni).tconst_pmtu_discover_fast, CI_PMTU_TCONST_DISCOVER_FAST,
             NI_CONF(ni).tconst_pmtu_discover_recover,
             CI_PMTU_TCONST_DISCOVER_RECOVER);
-  LOG_PRINT("  RFC 5961 challenge ack limit: %d per tick, %d per sec\n",
-            NI_CONF(ni).tconst_challenge_ack_limit,
-            NI_OPTS(ni).challenge_ack_limit);
   LOG_PRINT("  Time between ACKs sent as a response to invalid "
             "incoming TCP packets: %uticks (%ums)\n",
             NI_CONF(ni).tconst_invalid_ack_ratelimit,

--- a/src/lib/transport/ip/netif_init.c
+++ b/src/lib/transport/ip/netif_init.c
@@ -298,7 +298,6 @@ static ci_uint32 citp_syn_opts = CI_TCPT_SYN_FLAGS;
 static ci_uint32 citp_tcp_dsack = CI_CFG_TCP_DSACK;
 static ci_uint32 citp_tcp_time_wait_assassinate = CI_CFG_TIME_WAIT_ASSASSINATE;
 static ci_uint32 citp_tcp_early_retransmit = 3;  /* default as of 3.10 */
-static ci_uint32 citp_challenge_ack_limit = CI_CFG_CHALLENGE_ACK_LIMIT;
 static ci_uint32 citp_tcp_invalid_ratelimit =
                         CI_CFG_TCP_OUT_OF_WINDOW_ACK_RATELIMIT;
 
@@ -455,9 +454,6 @@ ci_setup_ipstack_params(void)
   if (ci_sysctl_get_values("net/ipv4/tcp_early_retrans", opt, 1) == 0)
     citp_tcp_early_retransmit = opt[0];
 
-  if (ci_sysctl_get_values("net/ipv4/tcp_challenge_ack_limit", opt, 1) == 0)
-    citp_challenge_ack_limit = opt[0];
-
   if (ci_sysctl_get_values("net/ipv4/tcp_invalid_ratelimit", opt, 1) == 0)
     citp_tcp_invalid_ratelimit = opt[0];
 
@@ -536,7 +532,6 @@ void ci_netif_config_opts_defaults(ci_netif_config_opts* opts)
     opts->tcp_early_retransmit = citp_tcp_early_retransmit > 0 &&
                                  citp_tcp_early_retransmit < 4;
     opts->tail_drop_probe = citp_tcp_early_retransmit >= 3;
-    opts->challenge_ack_limit = citp_challenge_ack_limit;
     opts->oow_ack_ratelimit = citp_tcp_invalid_ratelimit;
 #if CI_CFG_IPV6
     opts->auto_flowlabels = citp_auto_flowlabels;
@@ -916,8 +911,6 @@ void ci_netif_config_opts_getenv(ci_netif_config_opts* opts)
   opts->dynack_thresh = CI_MAX(opts->dynack_thresh, opts->delack_thresh);
 #endif
 
-  if ( (s = getenv("EF_CHALLENGE_ACK_LIMIT")) )
-    opts->challenge_ack_limit = atoi(s);
   if ( (s = getenv("EF_INVALID_ACK_RATELIMIT")) )
     opts->oow_ack_ratelimit = atoi(s);
 #if CI_CFG_FD_CACHING

--- a/src/lib/transport/ip/tcp_timer.c
+++ b/src/lib/transport/ip/tcp_timer.c
@@ -69,11 +69,6 @@ void ci_tcp_timer_init(ci_netif* netif)
   NI_CONF(netif).tconst_pmtu_discover_recover = 
     ci_tcp_time_ms2ticks(netif, CI_PMTU_TCONST_DISCOVER_RECOVER);
 
-  /* Convert per-second challenge ACK limit to a per-tick.
-   * +1 to ensure that the result is non-zero. */
-  NI_CONF(netif).tconst_challenge_ack_limit =
-      ci_ip_time_freq_hz2tick(netif, NI_OPTS(netif).challenge_ack_limit) + 1;
-
   if( NI_OPTS(netif).oow_ack_ratelimit == 0 )
     NI_CONF(netif).tconst_invalid_ack_ratelimit = 0;
   else

--- a/src/lib/transport/ip/tcp_tx.c
+++ b/src/lib/transport/ip/tcp_tx.c
@@ -2058,22 +2058,8 @@ int ci_tcp_send_challenge_ack(ci_netif* netif, ci_tcp_state* ts,
   if( ! ci_tcp_may_send_ack_ratelimited(netif, ts) )
     return 0;
 
-  if( netif->state->challenge_ack_time != ci_tcp_time_now(netif) ) {
-    netif->state->challenge_ack_time = ci_tcp_time_now(netif);
-    netif->state->challenge_ack_num = 0;
-  }
-  if( netif->state->challenge_ack_num >=
-      NI_CONF(netif).tconst_challenge_ack_limit ) {
-    CITP_STATS_NETIF_INC(netif, challenge_ack_limited);
-    return 0;
-  }
-
-  netif->state->challenge_ack_num++;
   pkt = ci_netif_pkt_rx_to_tx(netif, pkt);
   if( pkt == NULL ) {
-    /* Avoid more challenge ACK during this tick. */
-    netif->state->challenge_ack_num =
-                    NI_CONF(netif).tconst_challenge_ack_limit;
     CITP_STATS_NETIF_INC(netif, challenge_ack_out_of_pkts);
     return 1; /* The packet have been consumed in any case */
   }

--- a/src/tools/onload_remote_monitor/ftl_defs.h
+++ b/src/tools/onload_remote_monitor/ftl_defs.h
@@ -316,8 +316,6 @@ typedef struct oo_p_dllink oo_p_dllink_t;
                  ci_iptime_t, tconst_pmtu_discover_fast, ORM_OUTPUT_STACK)                \
   FTL_TFIELD_INT(ctx, \
                  ci_iptime_t, tconst_pmtu_discover_recover, ORM_OUTPUT_STACK)             \
-  FTL_TFIELD_INT(ctx, \
-                 ci_uint32, tconst_challenge_ack_limit, ORM_OUTPUT_STACK) \
   FTL_TFIELD_INT(ctx, ci_iptime_t, tconst_stats, ORM_OUTPUT_STACK)       \
   FTL_TSTRUCT_END(ctx)                                                 
 
@@ -519,8 +517,6 @@ typedef struct oo_p_dllink oo_p_dllink_t;
   FTL_TFIELD_ARRAYOFSTRUCT(ctx, oo_p_dllink_t, timeout_q, \
                            OO_TIMEOUT_Q_MAX, ORM_OUTPUT_STACK, 1)         \
   FTL_TFIELD_STRUCT(ctx, oo_p_dllink_t, reap_list, ORM_OUTPUT_EXTRA)     \
-  FTL_TFIELD_INT(ctx, ci_uint32, challenge_ack_num, ORM_OUTPUT_STACK)     \
-  FTL_TFIELD_INT(ctx, ci_iptime_t, challenge_ack_time, ORM_OUTPUT_STACK)  \
   ON_CI_CFG_SUPPORT_STATS_COLLECTION(                                   \
     FTL_TFIELD_INT(ctx, ci_int32, stats_fmt, ORM_OUTPUT_STACK)            \
     FTL_TFIELD_STRUCT(ctx, ci_ip_timer, stats_tid, ORM_OUTPUT_STACK)      \


### PR DESCRIPTION
In linux-6.0 challenge_ack_limit have been deprecated in 79e3602caa6f9d59c4f66a268407080496dae408 ,
following implementation of per-socket limitation of challenge ACK in f2b2c582e82429270d5818fbabe653f4359d7024 .

Onload already applies per-socket limitation for challenge ACK, see the very beginning of ci_tcp_send_challenge_ack().  So it is safe to follow linux and remove global/per-stack limitation for challenge ACKs.

Additionally, it removes following Onload warning on linux>=6.0:
config: ERROR - option challenge_ack_limit (2147483647) larger than maximum

----

I do not have any specific tests for this, but I've checked that it basically works.
And I do not see the error any more.