### PR TITLE
ON-14617: Deprecate EF_CHALLENGE_ACK_LIMIT

### DIFF
--- a/src/include/ci/internal/opts_netif_def.h
+++ b/src/include/ci/internal/opts_netif_def.h
@@ -860,7 +860,7 @@ CI_CFG_OPT("EF_CHALLENGE_ACK_LIMIT", challenge_ack_limit,
 "window attack mitigation, RFC 5961; in packets per second.  "
 "The limitation applies for each Onload stack separately.\n"
 "The value from /proc/sys/net/ipv4/tcp_challenge_ack_limit is used by default.",
-          , , CI_CFG_CHALLENGE_ACK_LIMIT, 0, 65535, count)
+          , , CI_CFG_CHALLENGE_ACK_LIMIT, 0, INT_MAX, count)
 
 CI_CFG_OPT("EF_INVALID_ACK_RATELIMIT", oow_ack_ratelimit, ci_uint32,
 "Limit the rate of ACKs sent because of invalid incoming TCP packet, "

--- a/src/include/ci/internal/transport_config_opt.h
+++ b/src/include/ci/internal/transport_config_opt.h
@@ -316,9 +316,13 @@
  * Default value for EF_TCP_TIME_WAIT_ASSASSINATION. */
 #define CI_CFG_TIME_WAIT_ASSASSINATE 1
 
-/* Default challenge ACK limitation (in count per second),
- * same as of linux-4.19 */
-#define CI_CFG_CHALLENGE_ACK_LIMIT 1000
+#ifndef __KERNEL__
+#include <limits.h>
+#endif
+
+/* The Linux kernel disables challenge ACK limitation (in count per second),
+ * by default since 6.0.*/
+#define CI_CFG_CHALLENGE_ACK_LIMIT INT_MAX
 
 /* Default ACK limitation when sending respnse to invalid packet,
  * in ms, same as of linux-4.19 */

--- a/src/lib/transport/ip/netif_init.c
+++ b/src/lib/transport/ip/netif_init.c
@@ -24,6 +24,7 @@
 #ifndef __KERNEL__
 #include <cplane/cplane.h>
 #include <cplane/create.h>
+#include <limits.h>
 #include <net/if.h>
 #include <ci/internal/efabcfg.h>
 #if CI_CFG_PKTS_AS_HUGE_PAGES
@@ -922,8 +923,11 @@ void ci_netif_config_opts_getenv(ci_netif_config_opts* opts)
   opts->dynack_thresh = CI_MAX(opts->dynack_thresh, opts->delack_thresh);
 #endif
 
-  if ( (s = getenv("EF_CHALLENGE_ACK_LIMIT")) )
+  if ( (s = getenv("EF_CHALLENGE_ACK_LIMIT")) ) {
+    ci_log("EF_CHALLENGE_ACK_LIMIT is deprecated, "
+           "use EF_INVALID_ACK_RATELIMIT instead");
     opts->challenge_ack_limit = atoi(s);
+  }
   if ( (s = getenv("EF_INVALID_ACK_RATELIMIT")) )
     opts->oow_ack_ratelimit = atoi(s);
 #if CI_CFG_FD_CACHING

--- a/src/lib/transport/ip/tcp_tx.c
+++ b/src/lib/transport/ip/tcp_tx.c
@@ -19,6 +19,9 @@
 #include <ci/internal/pio_buddy.h>
 #include "tcp_tx.h"
 
+#ifndef __KERNEL__
+#include <limits.h>
+#endif
 
 #if OO_DO_STACK_POLL
 #define LPF "TCP TX "
@@ -2063,7 +2066,8 @@ int ci_tcp_send_challenge_ack(ci_netif* netif, ci_tcp_state* ts,
     netif->state->challenge_ack_num = 0;
   }
   if( netif->state->challenge_ack_num >=
-      NI_CONF(netif).tconst_challenge_ack_limit ) {
+      NI_CONF(netif).tconst_challenge_ack_limit &&
+      NI_OPTS(netif).challenge_ack_limit != INT_MAX ) {
     CITP_STATS_NETIF_INC(netif, challenge_ack_limited);
     return 0;
   }

--- a/src/lib/transport/unix/internal.h
+++ b/src/lib/transport/unix/internal.h
@@ -34,6 +34,7 @@
 #include <aio.h>
 #include <sys/types.h>
 #include <sys/socket.h>
+#include <limits.h>
 #include <netinet/tcp.h>
 #include <sys/uio.h>
 #include <pthread.h>


### PR DESCRIPTION
The Linux kernel 6.0 since 79e3602caa6f disables the global challenge ACK rate limitation by default. It starts treating 2147483647 (i.e. `INT_MAX`) written to `/proc/sys/net/ipv4/tcp_challenge_ack_limit` as "unlimited".

Onload reads that value as the default for `EF_CHALLENGE_ACK_LIMIT`, and so to apply the same to Onload, this patch:

1. Extends the supported range of `EF_CHALLENGE_ACK_LIMIT` from [0..64K] to [0..`INT_MAX`]. Consequently, it addresses the following warning:
```
onload: config: ERROR - option challenge_ack_limit (2147483647) larger than maximum (65535)
```
2. Disables the rate limiting in `ci_tcp_send_challenge_ack()` when `EF_CHALLENGE_ACK_LIMIT` is `INT_MAX`, similarly to the Linux kernel.
3. Disables `EF_CHALLENGE_ACK_LIMIT` by default.
4. Adds a deprecation warning. We suggest using `EF_INVALID_ACK_RATELIMIT`, which exists in Linux kernel 3.19 since f2b2c582e824 as `/proc/sys/net/ipv4/tcp_challenge_ack_limit`.

A follow-up ChangeLog note is a separate patch. Additionally, Onload User Guide must reflect that.

Suggested-by: Alexandra Kossovsky <Alexandra.Kossovsky@oktetlabs.ru>