### PR TITLE
Fix aarch64 sys_call_table look up code

### DIFF
--- a/src/driver/linux_resource/ci_arm64_insn.c
+++ b/src/driver/linux_resource/ci_arm64_insn.c
@@ -1,0 +1,146 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+
+#include "ci_arm64_insn.h"
+
+#ifndef EFRM_HAVE_NEW_KALLSYMS
+/* X-SPDX-Source-URL: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git */
+/* X-SPDX-Source-Tag: v5.15.83 */
+/* X-SPDX-Source-File: arch/arm64/lib/insn.c */
+/* X-SPDX-License-Identifier: GPL-2.0-only */
+/* X-SPDX-Comment: Functions to inspect aarch64 instructions for the case when
+ *                 efrm_find_ksym() is unavailable. The "ci" prefix is added to
+ *                 public functions in order not to clash with kernel names. */
+
+static int aarch64_get_imm_shift_mask(enum aarch64_insn_imm_type type,
+						u32 *maskp, int *shiftp)
+{
+	u32 mask;
+	int shift;
+
+	switch (type) {
+	case AARCH64_INSN_IMM_26:
+		mask = BIT(26) - 1;
+		shift = 0;
+		break;
+	case AARCH64_INSN_IMM_19:
+		mask = BIT(19) - 1;
+		shift = 5;
+		break;
+	case AARCH64_INSN_IMM_16:
+		mask = BIT(16) - 1;
+		shift = 5;
+		break;
+	case AARCH64_INSN_IMM_14:
+		mask = BIT(14) - 1;
+		shift = 5;
+		break;
+	case AARCH64_INSN_IMM_12:
+		mask = BIT(12) - 1;
+		shift = 10;
+		break;
+	case AARCH64_INSN_IMM_9:
+		mask = BIT(9) - 1;
+		shift = 12;
+		break;
+	case AARCH64_INSN_IMM_7:
+		mask = BIT(7) - 1;
+		shift = 15;
+		break;
+	case AARCH64_INSN_IMM_6:
+	case AARCH64_INSN_IMM_S:
+		mask = BIT(6) - 1;
+		shift = 10;
+		break;
+	case AARCH64_INSN_IMM_R:
+		mask = BIT(6) - 1;
+		shift = 16;
+		break;
+	case AARCH64_INSN_IMM_N:
+		mask = 1;
+		shift = 22;
+		break;
+	default:
+		return -EINVAL;
+	}
+
+	*maskp = mask;
+	*shiftp = shift;
+
+	return 0;
+}
+
+#define ADR_IMM_HILOSPLIT	2
+#define ADR_IMM_SIZE		SZ_2M
+#define ADR_IMM_LOMASK		((1 << ADR_IMM_HILOSPLIT) - 1)
+#define ADR_IMM_HIMASK		((ADR_IMM_SIZE >> ADR_IMM_HILOSPLIT) - 1)
+#define ADR_IMM_LOSHIFT		29
+#define ADR_IMM_HISHIFT		5
+
+u64 ci_aarch64_insn_decode_immediate(enum aarch64_insn_imm_type type, u32 insn)
+{
+	u32 immlo, immhi, mask;
+	int shift;
+
+	switch (type) {
+	case AARCH64_INSN_IMM_ADR:
+		shift = 0;
+		immlo = (insn >> ADR_IMM_LOSHIFT) & ADR_IMM_LOMASK;
+		immhi = (insn >> ADR_IMM_HISHIFT) & ADR_IMM_HIMASK;
+		insn = (immhi << ADR_IMM_HILOSPLIT) | immlo;
+		mask = ADR_IMM_SIZE - 1;
+		break;
+	default:
+		if (aarch64_get_imm_shift_mask(type, &mask, &shift) < 0) {
+			pr_err("%s: unknown immediate encoding %d\n", __func__,
+			       type);
+			return 0;
+		}
+	}
+
+	return (insn >> shift) & mask;
+}
+
+/*
+ * Decode the imm field of a branch, and return the byte offset as a
+ * signed value (so it can be used when computing a new branch
+ * target).
+ */
+s32 ci_aarch64_get_branch_offset(u32 insn)
+{
+	s32 imm;
+
+	if (aarch64_insn_is_b(insn) || aarch64_insn_is_bl(insn)) {
+		imm = ci_aarch64_insn_decode_immediate(AARCH64_INSN_IMM_26, insn);
+		return (imm << 6) >> 4;
+	}
+
+	if (aarch64_insn_is_cbz(insn) || aarch64_insn_is_cbnz(insn) ||
+	    aarch64_insn_is_bcond(insn)) {
+		imm = ci_aarch64_insn_decode_immediate(AARCH64_INSN_IMM_19, insn);
+		return (imm << 13) >> 11;
+	}
+
+	if (aarch64_insn_is_tbz(insn) || aarch64_insn_is_tbnz(insn)) {
+		imm = ci_aarch64_insn_decode_immediate(AARCH64_INSN_IMM_14, insn);
+		return (imm << 18) >> 16;
+	}
+
+	/* Unhandled instruction */
+	BUG();
+}
+
+/*
+ * Extract the Op/CR data from a msr/mrs instruction.
+ */
+u32 ci_aarch64_insn_extract_system_reg(u32 insn)
+{
+	return (insn & 0x1FFFE0) >> 5;
+}
+
+s32 ci_aarch64_insn_adrp_get_offset(u32 insn)
+{
+	BUG_ON(!aarch64_insn_is_adrp(insn));
+	return ci_aarch64_insn_decode_immediate(AARCH64_INSN_IMM_ADR, insn) << 12;
+}
+/* X-SPDX-Restore: */
+#endif /* ! EFRM_HAVE_NEW_KALLSYMS */

--- a/src/driver/linux_resource/ci_arm64_insn.h
+++ b/src/driver/linux_resource/ci_arm64_insn.h
@@ -1,0 +1,12 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+#ifndef __CI_ARM64_INSN_H__
+#define __CI_ARM64_INSN_H__
+
+#include <ci/efrm/sysdep_linux.h>
+
+u64 ci_aarch64_insn_decode_immediate(enum aarch64_insn_imm_type type, u32 insn);
+s32 ci_aarch64_get_branch_offset(u32 insn);
+u32 ci_aarch64_insn_extract_system_reg(u32 insn);
+s32 ci_aarch64_insn_adrp_get_offset(u32 insn);
+
+#endif /* __CI_ARM64_INSN_H__ */

--- a/src/driver/linux_resource/ci_arm64_patching.c
+++ b/src/driver/linux_resource/ci_arm64_patching.c
@@ -1,0 +1,32 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+
+#include "ci_arm64_patching.h"
+#include <ci/efrm/sysdep_linux.h>
+
+#ifndef EFRM_HAVE_NEW_KALLSYMS
+/* X-SPDX-Source-URL: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git */
+/* X-SPDX-Source-Tag: v5.15.83 */
+/* X-SPDX-Source-File: arch/arm64/kernel/patching.c */
+/* X-SPDX-License-Identifier: GPL-2.0-only */
+/* X-SPDX-Comment: aarch64_insn_read() is used to read aarch64 instructions.
+ *                 We copy it here, for the case when efrm_find_ksym() is
+ *                 unavailable, since it is not exported for modules. The "ci"
+ *                 prefix is added in order not to clash with the kernel. */
+
+/*
+ * In ARMv8-A, A64 instructions have a fixed length of 32 bits and are always
+ * little-endian.
+ */
+int ci_aarch64_insn_read(void *addr, u32 *insnp)
+{
+	int ret;
+	__le32 val;
+
+	ret = copy_from_kernel_nofault(&val, addr, AARCH64_INSN_SIZE);
+	if (!ret)
+		*insnp = le32_to_cpu(val);
+
+	return ret;
+}
+/* X-SPDX-Restore: */
+#endif /* ! EFRM_HAVE_NEW_KALLSYMS */

--- a/src/driver/linux_resource/ci_arm64_patching.h
+++ b/src/driver/linux_resource/ci_arm64_patching.h
@@ -1,0 +1,9 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+#ifndef __CI_ARM64_PATCHING_H__
+#define __CI_ARM64_PATCHING_H__
+
+#include <linux/types.h>
+
+int ci_aarch64_insn_read(void *addr, u32 *insnp);
+
+#endif /* __CI_ARM64_PATCHING_H__ */

--- a/src/driver/linux_resource/mmake.mk
+++ b/src/driver/linux_resource/mmake.mk
@@ -62,7 +62,7 @@ TARGETS		:= $(RESOURCE_TARGET)
 
 x86_TARGET_SRCS   := syscall_x86.o
 
-arm64_TARGET_SRCS := syscall_aarch64.o
+arm64_TARGET_SRCS := syscall_aarch64.o ci_arm64_patching.o ci_arm64_insn.o
 
 
 ######################################################

--- a/src/driver/linux_resource/syscall_aarch64.c
+++ b/src/driver/linux_resource/syscall_aarch64.c
@@ -10,11 +10,22 @@ void** efrm_syscall_table = NULL;
 EXPORT_SYMBOL(efrm_syscall_table);
 
 
-static typeof(aarch64_insn_decode_immediate) *aarch64_insn_decode_immediate_sym;
-static typeof(aarch64_insn_read) *aarch64_insn_read_sym;
-static typeof(aarch64_insn_extract_system_reg) *aarch64_insn_extract_system_reg_sym;
-static typeof(aarch64_get_branch_offset) *aarch64_get_branch_offset_sym;
-static typeof(aarch64_insn_adrp_get_offset) *aarch64_insn_adrp_get_offset_sym;
+/* The kernel contains some neat routines for doing AArch64 code inspection.
+ * Some of them are available as inline routines, but some are unfortunately
+ * not exported to modules.
+ * So we use efrm_find_ksym() to resolve these functions if it is available.
+ * Otherwise we copy their implementations here.
+ */
+#ifdef EFRM_HAVE_NEW_KALLSYMS
+static typeof(aarch64_insn_decode_immediate) *ci_aarch64_insn_decode_immediate;
+static typeof(aarch64_insn_read) *ci_aarch64_insn_read;
+static typeof(aarch64_insn_extract_system_reg) *ci_aarch64_insn_extract_system_reg;
+static typeof(aarch64_get_branch_offset) *ci_aarch64_get_branch_offset;
+static typeof(aarch64_insn_adrp_get_offset) *ci_aarch64_insn_adrp_get_offset;
+#else
+#include "ci_arm64_patching.h"
+#include "ci_arm64_insn.h"
+#endif /* EFRM_HAVE_NEW_KALLSYMS */
 
 /* Depending on the kernel version, locating the syscall table may be more
  * or less straigthforward.
@@ -62,8 +73,11 @@ find_el_sync(void)
 {
   ci_uint8 *vectors;
   ci_uint32 insn;
-  ci_uint8 *el_sync = efrm_find_ksym("el0_sync");
+  ci_uint8 *el_sync = NULL;
 
+#ifdef EFRM_HAVE_NEW_KALLSYMS
+  el_sync = efrm_find_ksym("el0_sync");
+#endif
   if (el_sync != NULL)
     return el_sync;
 
@@ -75,7 +89,7 @@ find_el_sync(void)
   vectors += 5 * sizeof(ci_uint32);
 #endif
 #endif
-  if (aarch64_insn_read_sym(vectors, &insn)) {
+  if (ci_aarch64_insn_read(vectors, &insn)) {
     EFRM_WARN("%s: cannot read vbar_el1", __func__);
     return NULL;
   }
@@ -83,7 +97,7 @@ find_el_sync(void)
     EFRM_WARN("%s: el0_sync entry is not a branch", __func__);
     return NULL;
   }
-  el_sync = vectors + aarch64_get_branch_offset_sym(insn);
+  el_sync = vectors + ci_aarch64_get_branch_offset(insn);
 
   return el_sync;
 }
@@ -91,10 +105,13 @@ find_el_sync(void)
 static ci_uint8 *
 find_el_svc_entry(void)
 {
-  ci_uint8 *el_svc = efrm_find_ksym("el0_svc");
+  ci_uint8 *el_svc = NULL;
   ci_uint8 *el_sync;
   ci_uint32 insn;
 
+#ifdef EFRM_HAVE_NEW_KALLSYMS
+  el_svc = efrm_find_ksym("el0_svc");
+#endif
   if (el_svc != NULL)
     return el_svc;
   el_sync = find_el_sync();
@@ -102,25 +119,25 @@ find_el_svc_entry(void)
     return NULL;
 
   while (1) {
-    if (aarch64_insn_read_sym(el_sync, &insn)) {
+    if (ci_aarch64_insn_read(el_sync, &insn)) {
       EFRM_WARN("cannot read el0_sync code @ %d", __LINE__);
       return NULL;
     }
     if (aarch64_insn_is_mrs(insn) &&
-        aarch64_insn_extract_system_reg_sym(insn) == SYS_ESR_EL1) {
+        ci_aarch64_insn_extract_system_reg(insn) == SYS_ESR_EL1) {
       el_sync += 2 * sizeof(ci_uint32);
-      if (aarch64_insn_read_sym(el_sync, &insn)) {
+      if (ci_aarch64_insn_read(el_sync, &insn)) {
         EFRM_WARN("cannot read el0_sync code @ %d", __LINE__);
         return NULL;
       }
       if (!aarch64_insn_is_subs_imm(insn) ||
-          aarch64_insn_decode_immediate_sym(AARCH64_INSN_IMM_12, insn) !=
+          ci_aarch64_insn_decode_immediate(AARCH64_INSN_IMM_12, insn) !=
           ESR_ELx_EC_SVC64) {
         EFRM_WARN("%s: expected check for ESR_ELx_EC_SVC64", __func__);
         return NULL;
       }
       el_sync += sizeof(ci_uint32);
-      if (aarch64_insn_read_sym(el_sync, &insn)) {
+      if (ci_aarch64_insn_read(el_sync, &insn)) {
         EFRM_WARN("cannot read el0_sync code @ %d", __LINE__);
         return NULL;
       }
@@ -129,7 +146,7 @@ find_el_svc_entry(void)
         EFRM_WARN("%s: branching to el0_svc not found", __func__);
         return NULL;
       }
-      el_svc = el_sync + aarch64_get_branch_offset_sym(insn);
+      el_svc = el_sync + ci_aarch64_get_branch_offset(insn);
       break;
     }
     el_sync += sizeof(ci_uint32);
@@ -146,7 +163,7 @@ find_syscall_table_via_vbar(void)
   if (el_svc == NULL)
     return NULL;
 
-  if (aarch64_insn_read_sym(el_svc, &insn)) {
+  if (ci_aarch64_insn_read(el_svc, &insn)) {
     EFRM_WARN("cannot read el0_svc start @ %016lx", (unsigned long)el_svc);
     return NULL;
   }
@@ -154,41 +171,39 @@ find_syscall_table_via_vbar(void)
     EFRM_WARN("expected adrp instruction at el0_svc, found %08x", insn);
     return NULL;
   }
-  return CI_PTR_ALIGN_BACK(el_svc, SZ_4K) + aarch64_insn_adrp_get_offset_sym(insn);
+  return CI_PTR_ALIGN_BACK(el_svc, SZ_4K) + ci_aarch64_insn_adrp_get_offset(insn);
 }
 
 static void *find_syscall_table(void)
 {
-  void *syscalls = efrm_find_ksym("sys_call_table");
+  void *syscalls = NULL;
 
+#ifdef EFRM_HAVE_NEW_KALLSYMS
+  syscalls = efrm_find_ksym("sys_call_table");
+#endif
   if (syscalls != NULL)
     return syscalls;
 
-/* The kernel contains some neat routines for doing AArch64 code inspection.
- * Some of them are available as inline routines, but some are
- * unfortunately not exported to modules. We could reimplement them, of
- * course, but since we do efrm_find_ksym in other places, that seems like
- * the least effort path
- */
-
-  aarch64_insn_decode_immediate_sym =
+#ifdef EFRM_HAVE_NEW_KALLSYMS
+  ci_aarch64_insn_decode_immediate =
                           efrm_find_ksym("aarch64_insn_decode_immediate");
-  aarch64_insn_read_sym = efrm_find_ksym("aarch64_insn_read");
-  aarch64_insn_extract_system_reg_sym =
+  ci_aarch64_insn_read = efrm_find_ksym("aarch64_insn_read");
+  ci_aarch64_insn_extract_system_reg =
                           efrm_find_ksym("aarch64_insn_extract_system_reg");
-  aarch64_get_branch_offset_sym =
+  ci_aarch64_get_branch_offset =
                           efrm_find_ksym("aarch64_get_branch_offset");
-  aarch64_insn_adrp_get_offset_sym =
+  ci_aarch64_insn_adrp_get_offset =
                           efrm_find_ksym("aarch64_insn_adrp_get_offset");
-  if (aarch64_insn_decode_immediate_sym == NULL ||
-      aarch64_insn_read_sym == NULL ||
-      aarch64_insn_extract_system_reg_sym == NULL ||
-      aarch64_get_branch_offset_sym == NULL ||
-      aarch64_insn_adrp_get_offset_sym == NULL) {
+  if (ci_aarch64_insn_decode_immediate == NULL ||
+      ci_aarch64_insn_read == NULL ||
+      ci_aarch64_insn_extract_system_reg == NULL ||
+      ci_aarch64_get_branch_offset == NULL ||
+      ci_aarch64_insn_adrp_get_offset == NULL) {
     EFRM_WARN("%s: some symbols required for AArch64 assembler analysis "
               "are not found", __func__);
     return NULL;
   }
+#endif
 
   return find_syscall_table_via_vbar();
 }

--- a/src/driver/linux_resource/syscall_aarch64.c
+++ b/src/driver/linux_resource/syscall_aarch64.c
@@ -6,6 +6,12 @@
 #include <ci/efrm/debug_linux.h>
 #include <ci/efrm/syscall.h>
 
+#if 1
+#define TRAMP_DEBUG(x...) (void)0
+#else
+#define TRAMP_DEBUG(x...) EFRM_WARN(x)
+#endif
+
 void** efrm_syscall_table = NULL;
 EXPORT_SYMBOL(efrm_syscall_table);
 
@@ -26,6 +32,24 @@ static typeof(aarch64_insn_adrp_get_offset) *ci_aarch64_insn_adrp_get_offset;
 #include "ci_arm64_patching.h"
 #include "ci_arm64_insn.h"
 #endif /* EFRM_HAVE_NEW_KALLSYMS */
+
+#define CI_AARCH64_INSN_READ(_ptr, _insn)            \
+  do {                                               \
+    if (ci_aarch64_insn_read(_ptr, &(_insn))) {      \
+      EFRM_WARN("%s:%d: cannot read insn at %px",    \
+                __FUNCTION__, __LINE__, _ptr);       \
+      return NULL;                                   \
+    }                                                \
+  } while (0);
+
+/* Linux does not have any function to check for 'bti' instruction. So we
+ * define it by ourselves. */
+static inline bool aarch64_insn_is_bti(u32 code)
+{
+  u32 mask = 0xFFFFFF3F;
+  u32 val = 0xD503241F;
+  return (code & mask) == val;
+}
 
 /* Depending on the kernel version, locating the syscall table may be more
  * or less straigthforward.
@@ -68,6 +92,17 @@ static typeof(aarch64_insn_adrp_get_offset) *ci_aarch64_insn_adrp_get_offset;
  * be sure it will never break, so there are as many safety checks here as possible.
  */
 
+/* Modern kernels way (since 5.5) (tested on 5.15.83 and 5.10.110):
+ * - Instead of `el_sync` we look for `el0t_64_sync`. Some new code was added
+ *   to the exception handler. See find_el_sync() for more comments.
+ * - `el0t_64_sync` jumps to C function el0t_64_sync_handler(), which calls
+ *   specific function based on the value of esr_el1 system register. We look
+ *   for `el0_svc` here. See find_el_svc_entry() for more comments.
+ * - `el0_svc()` calls `do_el0_svc()`, which calls `el0_svc_common()` and passes
+ *   pointer to the syscall table as an argument. See find_syscall_table_via_vbar()
+ *   for more comments.
+ */
+
 static ci_uint8 *
 find_el_sync(void)
 {
@@ -83,6 +118,21 @@ find_el_sync(void)
 
   vectors = (ci_uint8 *)read_sysreg(vbar_el1);
   vectors += 8 * 128;
+
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 10, 105)
+  /* Skip code that was added in 5.10.105:
+   * 14000003        b       40c <vectors+0x40c>
+   */
+  vectors += AARCH64_INSN_SIZE;
+#endif
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 15, 0)
+  /* Skip code that was added in 4.15:
+   * d53bd07e        mrs     x30, tpidrro_el0
+   * d51bd07f        msr     tpidrro_el0, xzr
+   */
+  vectors += 2 * AARCH64_INSN_SIZE;
+#endif
+
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 14, 0)
   vectors += sizeof(ci_uint32);
 #if defined(CONFIG_VMAP_STACK)
@@ -99,7 +149,26 @@ find_el_sync(void)
   }
   el_sync = vectors + ci_aarch64_get_branch_offset(insn);
 
+  TRAMP_DEBUG("%s:%d: 'b el_sync' = %px (%x)", __FUNCTION__, __LINE__, vectors,
+              insn);
+  TRAMP_DEBUG("%s:%d: el_sync = %px", __FUNCTION__, __LINE__, el_sync);
+
   return el_sync;
+}
+
+static inline ci_uint8 *
+find_next_bl(ci_uint8 *ptr)
+{
+  ci_uint32 insn;
+
+  CI_AARCH64_INSN_READ(ptr, insn);
+
+  while (!aarch64_insn_is_bl(insn)) {
+    ptr += AARCH64_INSN_SIZE;
+    CI_AARCH64_INSN_READ(ptr, insn);
+  }
+
+  return ptr;
 }
 
 static ci_uint8 *
@@ -108,6 +177,9 @@ find_el_svc_entry(void)
   ci_uint8 *el_svc = NULL;
   ci_uint8 *el_sync;
   ci_uint32 insn;
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 5, 0)
+  ci_uint8 *last_bl;
+#endif
 
 #ifdef EFRM_HAVE_NEW_KALLSYMS
   el_svc = efrm_find_ksym("el0_svc");
@@ -117,6 +189,97 @@ find_el_svc_entry(void)
   el_sync = find_el_sync();
   if (el_sync == NULL)
     return NULL;
+
+  /* syscall entry code was rewritten to C in 5.5. So we need to use another
+   * approach for searching el0_svc.  */
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 5, 0)
+
+  /* Find el0t_64_sync_handler() call and jump to it. We assume that el0_sync
+   * does not contain any other `bl` instructions before this one. */
+  el_sync = find_next_bl(el_sync);
+  CI_AARCH64_INSN_READ(el_sync, insn);
+  TRAMP_DEBUG("%s:%d: 'bl el0t_64_sync_handler' = %px (%x)", __FUNCTION__,
+              __LINE__, el_sync, insn);
+  el_sync += ci_aarch64_get_branch_offset(insn);
+  TRAMP_DEBUG("%s:%d: el0t_64_sync_handler = %px", __FUNCTION__, __LINE__, el_sync);
+
+  /* el0t_64_sync_handler() contains switch-case:
+   *
+   * unsigned long esr = read_sysreg(esr_el1);
+   * switch (ESR_ELx_EC(esr)) {
+   * case ESR_ELx_EC_SVC64:
+   *     el0_svc(regs);
+   *     break;
+   * and so on ...
+   *
+   * Assembler looks like:
+   * d503233f        paciasp
+   * a9bf7bfd        stp     x29, x30, [sp, #-16]!
+   * 910003fd        mov     x29, sp
+   * d5385201        mrs     x1, esr_el1
+   * 531a7c22        lsr     w2, w1, #26
+   * f100f05f        cmp     x2, #0x3c
+   * 540000a9        b.ls    ffffffc008b6d2ec <el0t_64_sync_handler+0x2c>  // b.plast
+   * 97fffd2d        bl      ffffffc008b6c790 <el0_inv>
+   * a8c17bfd        ldp     x29, x30, [sp], #16
+   * d50323bf        autiasp
+   * d65f03c0        ret
+   * 7100f05f        cmp     w2, #0x3c
+   * 54ffff68        b.hi    ffffffc008b6d2dc <el0t_64_sync_handler+0x1c>  // b.pmore
+   * 90000123        adrp    x3, ffffffc008b91000 <__entry_tramp_data_start>
+   * 91004063        add     x3, x3, #0x10
+   * 38624862        ldrb    w2, [x3, w2, uxtw]
+   * 10000063        adr     x3, ffffffc008b6d30c <el0t_64_sync_handler+0x4c>
+   * 8b228862        add     x2, x3, w2, sxtb #2
+   * d61f0040        br      x2
+   * 97fffbf9        bl      ffffffc008b6c2f0 <el0_dbg>
+   * 17fffff4        b       ffffffc008b6d2e0 <el0t_64_sync_handler+0x20>
+   * ...
+   * 97ffff0a        bl      ffffffc008b6cf94 <el0_svc>
+   * 17ffffdc        b       ffffffc008b6d2e0 <el0t_64_sync_handler+0x20>
+   *
+   * We need `el0_svc`, which is the last one. Firstly jump to the `br`, and then
+   * find the last `bl` instruction.
+   */
+
+  /* Skip some code until we reach `br` instruction. */
+  while (!aarch64_insn_is_br(insn)) {
+    CI_AARCH64_INSN_READ(el_sync, insn);
+    el_sync += AARCH64_INSN_SIZE;
+  }
+
+  /* Find next 'bl' instruction. There may be a few 'bti' instructions
+   * or may be nothing (see listing above).
+   * Example for Linux-5.10 where we have them:
+   * d61f0040        br      x2
+   * d503249f        bti     j
+   * d503249f        bti     j
+   * d503249f        bti     j
+   * d503249f        bti     j
+   * 97ffff61        bl      b30 <el0_dbg>
+   */
+  el_sync = find_next_bl(el_sync);
+
+  /* Find the last bl instruction. It is jump to el0_svc. */
+  while (1) {
+    CI_AARCH64_INSN_READ(el_sync, insn);
+    /* Skip 'bti' instructions, which may be between 'bl's. */
+    if (aarch64_insn_is_bti(insn)) {
+      el_sync += AARCH64_INSN_SIZE;
+      continue;
+    }
+    if (!aarch64_insn_is_bl(insn))
+      break;
+    last_bl = el_sync;
+    el_sync += 2 * AARCH64_INSN_SIZE;
+  }
+  CI_AARCH64_INSN_READ(last_bl, insn);
+  el_svc = last_bl + ci_aarch64_get_branch_offset(insn);
+  TRAMP_DEBUG("%s:%d: 'bl el0_svc' = %px (%x)", __FUNCTION__, __LINE__, last_bl,
+              insn);
+  TRAMP_DEBUG("%s:%d: el0_svc = %px", __FUNCTION__, __LINE__, el_svc);
+
+#else
 
   while (1) {
     if (ci_aarch64_insn_read(el_sync, &insn)) {
@@ -151,6 +314,8 @@ find_el_svc_entry(void)
     }
     el_sync += sizeof(ci_uint32);
   }
+#endif
+
   return el_svc;
 }
 
@@ -159,9 +324,84 @@ find_syscall_table_via_vbar(void)
 {
   ci_uint8 *el_svc = find_el_svc_entry();
   ci_uint32 insn;
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 5, 0)
+  ci_uint8 *do_el0_svc = NULL;
+  ci_uint8 *sys_call_table = NULL;
+#endif
 
   if (el_svc == NULL)
     return NULL;
+
+  /* syscall entry code was rewritten to C in 5.5. So we need to use another
+   * approach for sys_call_table look up.  */
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 5, 0)
+
+  /*
+   * Linux-5.15:
+   * el0_svc() calls do_el0_svc() after some code. It is the 3d 'bl' instruction:
+   * <el0_svc>:
+   * d503233f        paciasp
+   * a9be7bfd        stp     x29, x30, [sp, #-32]!
+   * 910003fd        mov     x29, sp
+   * f9000bf3        str     x19, [sp, #16]
+   * aa0003f3        mov     x19, x0
+   * 97d930ee        bl      ffffffc0081b9360 <trace_hardirqs_off_finish>
+   * 97d2ae0d        bl      ffffffc0080187e0 <cortex_a76_erratum_1463225_svc_handler>
+   * aa1303e0        mov     x0, x19
+   * 97d2ebbc        bl      ffffffc008027ea4 <do_el0_svc>
+   */
+  el_svc = find_next_bl(el_svc);
+  el_svc += AARCH64_INSN_SIZE;
+
+  el_svc = find_next_bl(el_svc);
+
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 12, 0)
+  el_svc += AARCH64_INSN_SIZE;
+  el_svc = find_next_bl(el_svc);
+#endif
+
+  CI_AARCH64_INSN_READ(el_svc, insn);
+
+  /* Jumping to do_el0_svc(). */
+  do_el0_svc = el_svc + ci_aarch64_get_branch_offset(insn);
+  TRAMP_DEBUG("%s:%d: 'bl do_el0_svc' = %px (%x)", __FUNCTION__, __LINE__,
+              el_svc, insn);
+  TRAMP_DEBUG("%s:%d: do_el0_svc = %px", __FUNCTION__, __LINE__, do_el0_svc);
+
+  /* Next (and the last) we must find the function call where sys_call_table
+   * symbol is passed as an argument:
+   * el0_svc_common(regs, regs->regs[8], __NR_syscalls, sys_call_table);
+   *
+   * Assembler looks like:
+   * d0005b42        adrp    x2, ffffffc008b91000 <__entry_tramp_data_start>
+   * 911d2042        add     x2, x2, #0x748
+   * 97ffffad        bl      ffffffc008027d80 <el0_svc_common.constprop.0>
+   *
+   * The first two instructions form sys_call_table address.
+   */
+  do_el0_svc = find_next_bl(do_el0_svc);
+  do_el0_svc -= 2 * AARCH64_INSN_SIZE;
+
+  CI_AARCH64_INSN_READ(do_el0_svc, insn);
+  if (!aarch64_insn_is_adrp(insn)) {
+    EFRM_WARN("%s:%d: expected adrp instruction at %px, found %08x",
+              __FUNCTION__, __LINE__, do_el0_svc, insn);
+    return NULL;
+  }
+  sys_call_table = CI_PTR_ALIGN_BACK(do_el0_svc, SZ_4K) +
+          ci_aarch64_insn_adrp_get_offset(insn);
+
+  do_el0_svc += AARCH64_INSN_SIZE;
+  CI_AARCH64_INSN_READ(do_el0_svc, insn);
+  if (!aarch64_insn_is_add_imm(insn)) {
+    EFRM_WARN("%s:%d: expected add instruction at %px, found %08x",
+              __FUNCTION__, __LINE__, do_el0_svc, insn);
+    return NULL;
+  }
+  sys_call_table += ci_aarch64_insn_decode_immediate(AARCH64_INSN_IMM_12, insn);
+  TRAMP_DEBUG("%s: sys_call_table = %px", __FUNCTION__, sys_call_table);
+  return sys_call_table;
+ #endif
 
   if (ci_aarch64_insn_read(el_svc, &insn)) {
     EFRM_WARN("cannot read el0_svc start @ %016lx", (unsigned long)el_svc);


### PR DESCRIPTION
Fix aarch64 `sys_call_table` look up code to be compatible with modern kernels.

Tested on Raspberry Pi 4 Model B Rev 1.4 with Debian 11 with kernel versions 5.15.83, 5.10.110, 5.4.83:
```bash
# Build and load is ok
sudo ./scripts/onload_install --no-sfc --no-initramfs
sudo onload_tool reload --onload-only

# Registering AF_XDP interface is ok
echo /home/pi/onload/src/tools/bpf_link_helper/bpf-link-helper | sudo tee /sys/module/sfc_resource/parameters/bpf_link_helper
echo eth0 | sudo tee /sys/module/sfc_resource/afxdp/register

# Running netcat (active/passive connections). Stacks are created successfully, data passes
echo 0 | sudo tee /sys/module/sfc_resource/parameters/enable_af_xdp_flow_filters
sudo onload nc -l -p 6666
sudo onload nc 10.0.0.2 6666
```