### PR TITLE
Fix build for Linux 6.2

### DIFF
--- a/src/driver/linux_resource/kernel_compat.sh
+++ b/src/driver/linux_resource/kernel_compat.sh
@@ -152,6 +152,8 @@ EFRM_HAVE_MODULE_MUTEX		symbol	module_mutex	include/linux/module.h
 EFRM_HAVE_ITER_UBUF symbol ITER_UBUF include/linux/uio.h
 
 EFRM_HAVE_FLOW_RSS      symbol  FLOW_RSS    include/uapi/linux/ethtool.h
+
+EFRM_CLASS_DEVNODE_DEV_IS_CONST memtype struct_class devnode include/linux/device/class.h char*(*)(const struct device *, umode_t *)
 # TODO move onload-related stuff from net kernel_compat
 " | egrep -v -e '^#' -e '^$' | sed 's/[ \t][ \t]*/:/g'
 }

--- a/src/include/ci/driver/chrdev.h
+++ b/src/include/ci/driver/chrdev.h
@@ -43,8 +43,14 @@ ci_inline void destroy_chrdev_and_mknod(struct ci_chrdev_registration* reg)
 }
 
 
+#ifdef EFRM_CLASS_DEVNODE_DEV_IS_CONST
+/* Linux >= 6.2 */
+ci_inline char* chrdev_devnode_set_mode(const struct device* dev,
+                                        umode_t* mode)
+#else
 ci_inline char* chrdev_devnode_set_mode(struct device* dev,
                                         umode_t* mode)
+#endif
 {
   if( mode )
     *mode = (umode_t)(uintptr_t)dev_get_drvdata(dev);

--- a/src/lib/transport/ip/netif_table.c
+++ b/src/lib/transport/ip/netif_table.c
@@ -52,17 +52,17 @@ ci_inline ci_uint32 OCCUPIED(ci_netif_filter_table_entry_fast* entry)
   return ~STATE(entry) & EMPTY & TOMBSTONE;
 }
 
-#define __ID(entry) ((entry)->__id_and_state & FILTER_TABLE_ID_MASK)
+#define __CI_TBL_ID(entry) ((entry)->__id_and_state & FILTER_TABLE_ID_MASK)
 ci_inline ci_uint32 ID(ci_netif_filter_table_entry_fast* entry)
 {
   ci_assert(OCCUPIED(entry));
-  return __ID(entry);
+  return __CI_TBL_ID(entry);
 }
 
 ci_inline void
 set_entry_state(ci_netif_filter_table_entry_fast* entry, ci_uint32 state)
 {
-  entry->__id_and_state = __ID(entry) | state;
+  entry->__id_and_state = __CI_TBL_ID(entry) | state;
 }
 
 #if OO_DO_STACK_POLL
@@ -382,7 +382,7 @@ ci_ip4_netif_filter_insert(ci_netif_filter_table* tbl,
                 CI_IP_PROTOCOL_STR(protocol),
     ip_addr_str(laddr), (unsigned) CI_BSWAP_BE16(lport),
     ip_addr_str(raddr), (unsigned) CI_BSWAP_BE16(rport),
-    first, hash2, hash1, STATE(entry), __ID(entry), hops));
+    first, hash2, hash1, STATE(entry), __CI_TBL_ID(entry), hops));
 
 #if CI_CFG_STATS_NETIF
   if( hops > netif->state->stats.table_max_hops )


### PR DESCRIPTION
Fix the errors happening on Linux 6.2:
```
onload/src/include/ci/driver/chrdev.h:89:23: error: assignment to ‘char * (*)(const struct device *, umode_t *)’ {aka ‘char * (*)(const struct device *, short unsigned int *)’} from incompatible pointer type ‘char * (*)(struct device *, umode_t *)’ {aka ‘char * (*)(struct device *, short unsigned int *)’} [-Werror=incompatible-pointer-types]
   reg->class->devnode = chrdev_devnode_set_mode;
```
and
```
build/x86_64_linux-6.2.10-1.el9.elrepo.x86_64/lib/transport/ip/netif_table.c:55: error: "__ID" redefined [-Werror]
   55 | #define __ID(entry) ((entry)->__id_and_state & FILTER_TABLE_ID_MASK)
      | 
In file included from ./include/linux/btf.h:10,
                 from ./include/linux/bpf.h:28,
                 from ./include/linux/filter.h:9,
                 from /home/nikitins/work/v5/src/include/ci/driver/kernel_compat.h:57,
                 from /home/nikitins/work/v5/src/include/ci/driver/platform/linux_kernel.h:90,
                 from /home/nikitins/work/v5/src/include/ci/driver/internal.h:51,
                 from /home/nikitins/work/v5/src/include/onload/oo_shmbuf.h:4,
                 from /home/nikitins/work/v5/src/include/ci/internal/ip.h:51,
                 from /home/nikitins/work/v5/build/x86_64_linux-6.2.10-1.el9.elrepo.x86_64/lib/transport/ip/ip_internal.h:19,
                 from /home/nikitins/work/v5/build/x86_64_linux-6.2.10-1.el9.elrepo.x86_64/lib/transport/ip/netif_table.c:17:
./include/linux/btf_ids.h:51: note: this is the location of the previous definition
   51 | #define __ID(prefix) \
      | 
```

Checked by compiling and loading Onload on CentOS 9 with kernels `6.1.9-1.el9.elrepo.x86_64` and `6.2.10-1.el9.elrepo.x86_64`. Both work.