### PR TITLE
Refactor hugepage allocation in the kernel

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -123,6 +123,7 @@ mkdirs:
 	@mkdir -p $(obj)/src/lib/efhw
 	@mkdir -p $(obj)/src/lib/efrm
 	@mkdir -p $(obj)/src/lib/efthrm
+	@mkdir -p $(obj)/src/lib/kernel_utils
 
 # Define the high-level dependencies between libraries:
 $(obj)/src/driver/linux_resource: $(AUTOCOMPAT) mkdirs
@@ -130,6 +131,7 @@ $(obj)/src/lib/transport/ip: $(AUTOCOMPAT)
 $(obj)/src/lib/ciul: $(AUTOCOMPAT)
 $(obj)/src/lib/citools: $(AUTOCOMPAT)
 $(obj)/src/lib/cplane: $(AUTOCOMPAT) $(obj)/src/lib/ciul
+$(obj)/src/lib/kernel_utils: $(AUTOCOMPAT)
 $(obj)/src/driver/linux_char: $(AUTOCOMPAT)
 $(obj)/src/driver/linux_char: $(obj)/src/lib/citools $(obj)/src/lib/ciul
 $(obj)/src/driver/linux_onload: $(obj)/src/lib/citools $(obj)/src/lib/ciul \

--- a/scripts/onload_mkdist
+++ b/scripts/onload_mkdist
@@ -140,7 +140,7 @@ try cd "$releasedir"
 
 # Copy lots of sources.
 docopy src/lib                citools ciul ciapp efhw efrm efthrm cplane
-docopy src/lib                onload_ext
+docopy src/lib                onload_ext kernel_utils
 docopy src/lib/transport      common ip unix
 docopy src/driver             linux linux_resource linux_char
 docopy src/driver             linux_onload
@@ -149,7 +149,7 @@ docopy src/tools/ip           sockbuf_filter.h
 docopy src/tools/ip           tcpdump_bin.c fuser.c
 docopy src/tools              jni onload_remote_monitor cplane onload_mibdump
 docopy src/tools              onload_helper
-docopy src/include            etherfabric onload cplane
+docopy src/include            etherfabric onload cplane kernel_utils
 docopy src/include/ci         compat compat.h tools tools.h app app.h
 docopy src/include/ci         driver efch efhw efrm internal net
 

--- a/src/driver/linux_onload/linux_syscall.c
+++ b/src/driver/linux_onload/linux_syscall.c
@@ -94,28 +94,3 @@ asmlinkage int efab_linux_sys_epoll_wait(int epfd, struct epoll_event *events,
 #endif
 }
 
-#ifdef OO_DO_HUGE_PAGES
-asmlinkage int efab_linux_sys_shmget(key_t key, size_t size, int shmflg)
-{
-  return (int)SYSCALL_DISPATCHn(3, shmget, (key_t, size_t, int),
-                                key, size, shmflg);
-}
-
-asmlinkage long efab_linux_sys_shmat(int shmid, char __user *addr, int shmflg)
-{
-  return (long)SYSCALL_DISPATCHn(3, shmat, (int, char*, int),
-                                 shmid, addr, shmflg);
-}
-
-asmlinkage int efab_linux_sys_shmdt(char __user *addr)
-{
-  return (int)SYSCALL_DISPATCHn(1, shmdt, (char*), addr);
-}
-
-asmlinkage int efab_linux_sys_shmctl(int shmid, int cmd, struct shmid_ds __user *buf)
-{
-  return (int)SYSCALL_DISPATCHn(3, shmctl, (int, int, struct shmid_ds*),
-                                shmid, cmd, buf);
-}
-#endif
-

--- a/src/driver/linux_onload/mmap.c
+++ b/src/driver/linux_onload/mmap.c
@@ -465,7 +465,7 @@ static int tcp_helper_rm_mmap_pkts(tcp_helper_resource_t* trs,
     return -EINVAL;
   }
 #ifdef OO_DO_HUGE_PAGES
-  if( oo_iobufset_get_shmid(ni->pkt_bufs[bufid]) >= 0 ) {
+  if( oo_iobufset_get_hugetlb_page(ni->pkt_bufs[bufid]) ) {
     OO_DEBUG_ERR(ci_log("%s: [%d] WARNING mmapping huge page from bufset=0x%"
                         PRIx64 " will split it", __func__, trs->id, bufid));
   }

--- a/src/driver/linux_resource/Kbuild
+++ b/src/driver/linux_resource/Kbuild
@@ -10,4 +10,5 @@ obj-m := $(RESOURCE_TARGET)
 sfc_resource-objs := $(RESOURCE_SRCS:%.c=%.o) \
                      $(EFHW_SRCS:%.c=../../lib/efhw/%.o) \
                      $(EFRM_SRCS:%.c=../../lib/efrm/%.o) \
+                     $(UTILS_SRCS:%.c=../../lib/kernel_utils/%.o) \
                      $($(ARCH)_TARGET_SRCS:%.c=%.o)

--- a/src/driver/linux_resource/kernel_compat.sh
+++ b/src/driver/linux_resource/kernel_compat.sh
@@ -66,6 +66,7 @@ EFRM_GUP_RCLONG_TASK_SEPARATEFLAGS symtype get_user_pages include/linux/mm.h lon
 EFRM_GUP_RCLONG_TASK_COMBINEDFLAGS symtype get_user_pages include/linux/mm.h long(struct task_struct *, struct mm_struct *, unsigned long, unsigned long, unsigned int, struct page **, struct vm_area_struct **)
 EFRM_GUP_RCLONG_NOTASK_COMBINEDFLAGS symtype get_user_pages include/linux/mm.h long(unsigned long, unsigned long, unsigned int, struct page **, struct vm_area_struct **)
 EFRM_GUP_HAS_PIN	symbol	pin_user_pages	include/linux/mm.h
+EFRM_GUP_HAS_DMA_PINNED	symbol	page_maybe_dma_pinned	include/linux/mm.h
 
 EFRM_HAVE_USERMODEHELPER_SETUP		symbol	call_usermodehelper_setup	include/linux/kmod.h
 EFRM_HAVE_USERMODEHELPER_SETUP_INFO	symtype	call_usermodehelper_setup	include/linux/kmod.h	struct subprocess_info*(char *path, char **argv, char **envp, gfp_t gfp_mask, int (*init)(struct subprocess_info *info, struct cred *new), void (*cleanup)(struct subprocess_info *), void *data)

--- a/src/driver/linux_resource/mmake.mk
+++ b/src/driver/linux_resource/mmake.mk
@@ -43,6 +43,9 @@ EFRM_SRCS	:=			\
 EFRM_HDRS	:= efrm_internal.h efrm_vi.h efrm_vi_set.h \
 		efrm_pd.h efrm_pio.h bt_manager.h
 
+UTILS_HDRS	:= hugetlb.h
+UTILS_SRCS	:= hugetlb.c
+
 ifeq ($(HAVE_SFC),1)
 RESOURCE_SRCS += driverlink_new.c
 EFHW_SRCS += ef10.c ef100.c
@@ -52,11 +55,13 @@ IMPORT		:= $(EFHW_SRCS:%=../../lib/efhw/%) \
 		   $(EFHW_HDRS:%=../../lib/efhw/%) \
 		   $(EFRM_SRCS:%=../../lib/efrm/%) \
 		   $(EFRM_HDRS:%=../../lib/efrm/%) \
+		   $(UTILS_SRCS:%=../../lib/kernel_utils/%) \
+		   $(UTILS_HDRS:%=../../include/kernel_utils/%) \
 		   ../linux_net/drivers/net/ethernet/sfc/driverlink_api.h
 
 
 RESOURCE_TARGET	:= sfc_resource.o
-RESOURCE_TARGET_SRCS := $(RESOURCE_SRCS) $(EFHW_SRCS) $(EFRM_SRCS)
+RESOURCE_TARGET_SRCS := $(RESOURCE_SRCS) $(EFHW_SRCS) $(EFRM_SRCS) $(UTILS_SRCS)
 
 TARGETS		:= $(RESOURCE_TARGET)
 

--- a/src/driver/linux_resource/mmake.mk
+++ b/src/driver/linux_resource/mmake.mk
@@ -37,7 +37,7 @@ EFRM_SRCS	:=			\
 		vi_allocator.c		\
 		buddy.c			\
 		bt_manager.c		\
-		driver_object.c         \
+		driver_object.c		\
 		licensing.c
 
 EFRM_HDRS	:= efrm_internal.h efrm_vi.h efrm_vi_set.h \

--- a/src/include/ci/driver/kernel_compat.h
+++ b/src/include/ci/driver/kernel_compat.h
@@ -171,6 +171,16 @@ static inline void unpin_user_page(struct page *page)
 }
 #endif
 
+#ifndef EFRM_GUP_HAS_DMA_PINNED
+/* page_maybe_dma_pinned() was not added at the same time as pin_user_pages(),
+ * but shortly after, around linux-5.7. We could mimic it, but the real value
+ * for us is the post linux-6.1 kernels, which may change the pinning semantics
+ * and break our assumptions that vm_munmap() does not unpin pages. */
+static inline bool page_maybe_dma_pinned(struct page *page)
+{
+  return true;
+}
+#endif
 
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4,10,0)
 #define VM_FAULT_ADDRESS(_vmf) (_vmf)->address

--- a/src/include/ci/efch/op_types.h
+++ b/src/include/ci/efch/op_types.h
@@ -142,7 +142,6 @@ struct efch_efct_rxq_alloc {
   /*bool*/uint8_t     in_timestamp_req;
   uint32_t            in_n_hugepages;
   int32_t             in_memfd;
-  uint64_t            in_memfd_off;
 };
 
 

--- a/src/include/ci/efhw/efct.h
+++ b/src/include/ci/efhw/efct.h
@@ -12,6 +12,7 @@ extern struct efhw_func_ops efct_char_functional_units;
 struct efhw_efct_rxq;
 struct efct_client_hugepage;
 struct efct_client_rxq_params;
+struct oo_hugetlb_allocator;
 typedef void efhw_efct_rxq_free_func_t(struct efhw_efct_rxq*);
 typedef void efhw_efct_rxq_int_wake_func_t(struct efhw_efct_rxq*);
 
@@ -185,7 +186,8 @@ struct efhw_nic_efct {
 
 #if CI_HAVE_EFCT_AUX
 int efct_nic_rxq_bind(struct efhw_nic *nic, int qid, bool timestamp_req,
-                      size_t n_hugepages, struct file* memfd, off_t* memfd_off,
+                      size_t n_hugepages,
+                      struct oo_hugetlb_allocator *hugetlb_alloc,
                       struct efab_efct_rxq_uk_shm_q *shm,
                       unsigned wakeup_instance, struct efhw_efct_rxq *rxq);
 void efct_nic_rxq_free(struct efhw_nic *nic, struct efhw_efct_rxq *rxq,

--- a/src/include/ci/efrm/efct_rxq.h
+++ b/src/include/ci/efrm/efct_rxq.h
@@ -8,6 +8,7 @@ struct efrm_resource;
 struct efrm_resource_manager;
 struct efrm_vi;
 struct efrm_efct_rxq;
+struct oo_hugetlb_allocator;
 
 int efrm_create_rxq_resource_manager(struct efrm_resource_manager **rm_out);
 
@@ -16,7 +17,7 @@ extern struct efrm_efct_rxq* efrm_rxq_from_resource(struct efrm_resource *rs);
 
 extern int efrm_rxq_alloc(struct efrm_vi *vi, int qid, int shm_ix,
                           bool timestamp_req, size_t n_hugepages,
-                          struct file* memfd, off_t* memfd_off,
+                          struct oo_hugetlb_allocator *hugetlb_alloc,
                           struct efrm_efct_rxq **rxq_out);
 
 extern void efrm_rxq_release(struct efrm_efct_rxq *rxq);

--- a/src/include/ci/internal/ip_shared_types.h
+++ b/src/include/ci/internal/ip_shared_types.h
@@ -871,7 +871,7 @@ typedef struct {
   oo_pkt_p              free;   /**< List of free packet buffers */
   ci_int32              n_free; /**< Number of buffers in free list */
 #if defined(CI_CFG_PKTS_AS_HUGE_PAGES)
-  CI_ULCONST ci_int32   shm_id; /**< shared memory id for huge page  */
+  CI_ULCONST ci_int32   page_offset;
 #endif
   CI_ULCONST ci_uint32  dma_addr_base; /**< Index into ci_netif::dma_addrs */
   ci_uint8              page_order; /**< Bitshift to get from packet ID to the

--- a/src/include/ci/tools/platform/unix.h
+++ b/src/include/ci/tools/platform/unix.h
@@ -92,6 +92,20 @@ typedef struct iovec ci_iovec;
 #define CI_IOVEC_BASE(i) ((i)->iov_base)
 #define CI_IOVEC_LEN(i)  ((i)->iov_len)
 
+/* The memfd_create() system call first appeared in Linux 3.17, glibc
+ * support was added in version 2.27, MFD_HUGETLB is available on Linux
+ * since 4.14, as per man 2 memfd_create. To support newer kernels with
+ * older glibc (e.g. in containers), we define these ourselves. At the
+ * same time, they won't cause issues in the newer configurations where
+ * they are available, as long as they are the correct values because
+ * the macro redefinition is silently ignored. */
+#define MFD_CLOEXEC 1U
+#define MFD_HUGETLB 4U
+#if defined __x86_64__
+#define __NR_memfd_create 319
+#elif defined __aarch64__
+#define __NR_memfd_create 279
+#endif
 
 #endif  /* __CI_TOOLS_UNIX_H__ */
 

--- a/src/include/kernel_utils/hugetlb.h
+++ b/src/include/kernel_utils/hugetlb.h
@@ -1,0 +1,139 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+/* X-SPDX-Copyright-Text: (c) Copyright 2023 Advanced Micro Devices, Inc. */
+/*
+ ****************************************************************************
+ *
+ * A library to allocate hugepages in the kernelspace
+ * (which is not encouraged and not straightforward).
+ *
+ * How it works: the userspace donates a memfd file to the kernel module via
+ * ioctl(). Then the library calls ftruncate(), fallocate(), mmap(),
+ * pin_user_pages() and munmap() to get an instance of a 2 MiB hugepage,
+ * which we can give to NIC after dma_map_single(). For older kernels without
+ * the memfd support, the library calls hugetlb_file_setup() directly.
+ *
+ * Ideally, the userspace should do the allocation itself, i.e. ftruncate(),
+ * fallocate(), mmap(), and then make an ioctl() with the virtual address.
+ * In this case, we become aligned with the kernel API, and the library
+ * degenerates into a single pin_user_pages() call. This may require
+ * significant workflow refactoring in Onload.
+ *
+ ****************************************************************************
+ */
+
+#ifndef __OO_HUGETLB_H__
+#define __OO_HUGETLB_H__
+
+#include <onload/common.h>
+#include <onload/atomics.h>
+
+#define OO_HUGEPAGE_SIZE (2 * 1024 * 1024)
+
+struct oo_hugetlb_allocator {
+	struct file *filp;
+	off_t offset;
+	atomic_t refcnt;
+};
+
+struct oo_hugetlb_page {
+	struct file *filp;
+	struct page *page;
+};
+
+/* Create/destroy the memory allocator. */
+
+/*
+ * oo_hugetlb_allocator_create - Create a hugepage allocator.
+ *
+ * Parameters:
+ *   fd:             A donated memfd file descriptor to use for hugepage
+ *                   allocation or -1 on systems without memfd_create().
+ *
+ * Return:
+ *   On success, get a file reference identified by the file descriptor
+ *   or open a pseudo file with hugetlb_file_setup(), and return a valid
+ *   pointer to use later for allocation.
+ *
+ *   On failure, return a negative error number:
+ *     ENOSYS: Unable to find or call hugetlb_file_setup() in absence of memfd.
+ *     ENOMEM: Kernel memory allocation failure.
+ *     EINVAL: User error, e.g. a wrong file descriptor.
+ *     Those, returned by hugetlb_file_setup().
+ *
+ * Notes:
+ *   EINVAL should be treated as a fatal error indicating a software defect.
+ */
+extern struct oo_hugetlb_allocator *oo_hugetlb_allocator_create(int fd);
+
+extern struct oo_hugetlb_allocator *
+oo_hugetlb_allocator_get(struct oo_hugetlb_allocator *);
+
+extern void oo_hugetlb_allocator_put(struct oo_hugetlb_allocator *);
+
+static inline void
+oo_hugetlb_page_reset(struct oo_hugetlb_page *page)
+{
+	page->filp = NULL;
+	page->page = NULL;
+}
+
+/* Allocate/free one hugepage. */
+
+extern int
+oo_hugetlb_page_alloc_raw(struct oo_hugetlb_allocator *,
+		struct file **, struct page **);
+
+/*
+ * oo_hugetlb_page_alloc - Allocate one hugepage OO_HUGEPAGE_SIZE bytes.
+ *
+ * Return:
+ *   0 on success or a negative error number otherwise. Additionally,
+ *   reset an instance of oo_hugetlb_page so that oo_hugetlb_page_valid()
+ *   returns False, if allocation fails.
+ *
+ * Notes:
+ *   The hugepage allocator does not implement locking. The user must
+ *   serialise accesses to the allocator to prevent race conditions.
+ *
+ *   The hugepage instance is not tied to the allocator lifespan,
+ *   i.e. the users can legally destroy the allocator while the
+ *   hugepage is still in use.
+ *
+ *   Allocation happens on behalf of the userspace process and is not
+ *   suitable for the GFP_ATOMIC contexts.
+ */
+static inline int
+oo_hugetlb_page_alloc(struct oo_hugetlb_allocator *alloc,
+		struct oo_hugetlb_page *page)
+{
+	return oo_hugetlb_page_alloc_raw(alloc, &page->filp, &page->page);
+}
+
+extern void oo_hugetlb_page_free_raw(struct file *, struct page *);
+
+static inline void oo_hugetlb_page_free(struct oo_hugetlb_page *page)
+{
+	oo_hugetlb_page_free_raw(page->filp, page->page);
+	oo_hugetlb_page_reset(page);
+}
+
+/* Misc. */
+
+/*
+ * oo_hugetlb_pages_prealloc - Preallocate number of hugepages
+ * to support EF_PREALLOC_PACKETS.
+ *
+ * Return:
+ *   0 on success, or an error number returned by vfs_truncate()
+ *   or vfs_fallocate().
+ */
+extern int
+oo_hugetlb_pages_prealloc(struct oo_hugetlb_allocator *, int);
+
+static inline bool
+oo_hugetlb_page_valid(struct oo_hugetlb_page *page)
+{
+	return page->filp && page->page;
+}
+
+#endif /* __OO_HUGETLB_H__ */

--- a/src/include/onload/common.h
+++ b/src/include/onload/common.h
@@ -83,7 +83,8 @@ typedef struct ci_resource_onload_alloc_s {
   char                    in_name[CI_CFG_STACK_NAME_LEN + 1];
   int                     in_cluster_size;
   int                     in_cluster_restart;
-  int                     in_memfd;
+  int                     in_efct_memfd;
+  int                     in_pktbuf_memfd;
   efrm_nic_set_t          out_nic_set;
   ci_uint32               out_netif_mmap_bytes;
 } ci_resource_onload_alloc_t;
@@ -292,6 +293,11 @@ typedef struct {
   ci_user_ptr_t superbufs;
   ci_user_ptr_t current_mappings;
 } oo_efct_superbuf_config_refresh_t;
+
+typedef struct {
+  ci_uint32     offset;
+  ci_user_ptr_t addr;
+} oo_pkt_buf_map_t;
 
 /* Flags & types.  It could be enum if enum had fixed size. */
 typedef ci_uint16 oo_fd_flags;

--- a/src/include/onload/iobufset.h
+++ b/src/include/onload/iobufset.h
@@ -43,6 +43,7 @@
 #include <onload/common.h>
 #include <onload/linux_onload.h>
 #include <onload/atomics.h>
+#include <kernel_utils/hugetlb.h>
 
 /********************************************************************
  *
@@ -51,6 +52,7 @@
  ********************************************************************/
 
 struct efrm_pd;
+struct oo_hugetlb_allocator;
 
 /*
  * For all these structures, users should not access the structure fields
@@ -68,9 +70,7 @@ struct oo_buffer_pages {
   int n_bufs;               /*!< number of entries in pages array */
   oo_atomic_t ref_count;
 #ifdef OO_DO_HUGE_PAGES
-  int shmid;
-  struct file* shm_map_file;
-  void (*close)(struct vm_area_struct*);
+  struct oo_hugetlb_page hugetlb_page;
 #endif
   struct page **pages;     /*!< array of Linux compound pages */
 };
@@ -87,10 +87,12 @@ struct oo_iobufset {
 
 /*********** Find memory parameters ******************/
 #ifdef OO_DO_HUGE_PAGES
-/*! Are we shared memory backed? */
-ci_inline int oo_iobufset_get_shmid(struct oo_buffer_pages *pages)
+/*! Are we hugetlb backed? */
+ci_inline struct oo_hugetlb_page *
+oo_iobufset_get_hugetlb_page(struct oo_buffer_pages *pages)
 {
-  return pages->shmid;
+  return oo_hugetlb_page_valid(&pages->hugetlb_page) ? &pages->hugetlb_page :
+                                                    NULL;
 }
 #endif
 
@@ -110,7 +112,7 @@ ci_inline unsigned long oo_iobufset_pfn(struct oo_buffer_pages *pages, int offse
   /* This function is used from nopage handler.  Huge pages should not be
    * mmaped in this way. */
 #ifdef OO_DO_HUGE_PAGES
-  ci_assert_equal(pages->shmid, -1);
+  ci_assert(! oo_hugetlb_page_valid(&pages->hugetlb_page));
 #endif
 
   return page_to_pfn(pages->pages[offset >> PAGE_SHIFT >> order]) +
@@ -145,6 +147,7 @@ void oo_iobufset_kfree(struct oo_buffer_pages *pages);
  * \param min_nic_order minimum NIC page order
  * \param flags         see OO_IOBUFSET_FLAG_*, in/out
  * \param pages_out     pointer to return the allocated pages
+ * \param hugetlb_alloc pointer to the allocator, can be NULL
  *
  * \return              status code; if non-zero, pages_out is unchanged
  *
@@ -154,7 +157,8 @@ void oo_iobufset_kfree(struct oo_buffer_pages *pages);
  */
 extern int
 oo_iobufset_pages_alloc(int nic_order, int min_nic_order, int *flags,
-                        struct oo_buffer_pages **pages_out);
+                        struct oo_buffer_pages **pages_out,
+                        struct oo_hugetlb_allocator *hugetlb_alloc);
 extern void oo_iobufset_pages_release(struct oo_buffer_pages *);
 
 /*!

--- a/src/include/onload/iobufset.h
+++ b/src/include/onload/iobufset.h
@@ -62,7 +62,7 @@ struct efrm_pd;
  */
 
 
-/*! Continuous memorry allocation structure.
+/*! Continuous memory allocation structure.
  * All pages MUST have the same order. */
 struct oo_buffer_pages {
   int n_bufs;               /*!< number of entries in pages array */
@@ -75,7 +75,7 @@ struct oo_buffer_pages {
   struct page **pages;     /*!< array of Linux compound pages */
 };
 
-/*! Iobufset resource structture. */
+/*! Iobufset resource structure. */
 struct oo_iobufset {
   struct efrm_pd *pd;
   struct efrm_bt_collection buf_tbl_alloc;

--- a/src/include/onload/ioctl.h
+++ b/src/include/onload/ioctl.h
@@ -244,6 +244,9 @@ enum {
                                OO_IOC_W(EFCT_SUPERBUF_CONFIG_REFRESH, \
                                         oo_efct_superbuf_config_refresh_t)
 
+  OO_OP_PKT_BUF_MAP,
+#define OO_IOC_PKT_BUF_MMAP OO_IOC_RW(PKT_BUF_MAP, oo_pkt_buf_map_t)
+
   OO_OP_CONTIG_END,  /* This is the last in range of contigous opcodes */
 
   /* Here come only placeholder for operations with arbitrary codes */

--- a/src/include/onload/linux_onload.h
+++ b/src/include/onload/linux_onload.h
@@ -108,14 +108,6 @@ extern asmlinkage int efab_linux_sys_epoll_wait(int epfd,
 #if defined(CONFIG_HUGETLB_PAGE) && CI_CFG_PKTS_AS_HUGE_PAGES && \
    (defined(__x86_64__) || defined(__aarch64__))
 #define OO_DO_HUGE_PAGES
-#include <linux/mm.h>
-#include <linux/hugetlb.h>
-struct shmid_ds;
-asmlinkage int efab_linux_sys_shmget(key_t key, size_t size, int shmflg);
-asmlinkage long efab_linux_sys_shmat(int shmid, char __user *addr, int shmflg);
-asmlinkage int efab_linux_sys_shmdt(char __user *addr);
-asmlinkage int efab_linux_sys_shmctl(int shmid, int cmd,
-                                     struct shmid_ds __user *buf);
 #endif
 
 #ifdef CONFIG_NAMESPACES

--- a/src/include/onload/tcp_helper.h
+++ b/src/include/onload/tcp_helper.h
@@ -25,6 +25,7 @@
 
 /* Forwards. */
 typedef struct tcp_helper_endpoint_s tcp_helper_endpoint_t;
+struct oo_hugetlb_allocator;
 
 
 struct tcp_helper_nic {
@@ -127,6 +128,11 @@ typedef struct tcp_helper_cluster_s {
    * keyed by local IP address. */
   struct efab_ephemeral_port_head* thc_ephem_table;
   uint32_t                         thc_ephem_table_entries;
+
+  /* We retain a reference to the hugepage allocator merely to share it with
+   * the tcp_helper_resource_t instances that use it for the packet buffer
+   * allocation. */
+  struct oo_hugetlb_allocator*    thc_pktbuf_alloc;
 } tcp_helper_cluster_t;
 
 
@@ -349,6 +355,9 @@ typedef struct tcp_helper_resource_s {
   struct file*          thc_efct_memfd;
   /* byte offset in thc_efct_memfd of the next hugepage to allocate */
   off_t                 thc_efct_memfd_off;
+
+  /* backing store for packet buffers */
+  struct oo_hugetlb_allocator* thc_pktbuf_alloc;
 
   ci_waitable_t         ready_list_waitqs[CI_CFG_N_READY_LISTS];
   ci_dllist             os_ready_lists[CI_CFG_N_READY_LISTS];

--- a/src/include/onload/tcp_helper.h
+++ b/src/include/onload/tcp_helper.h
@@ -352,10 +352,7 @@ typedef struct tcp_helper_resource_s {
   /* bucket of rss hardware filter */
   int thc_rss_instance;
   /* backing store for efct's mmappable hugepages */
-  struct file*          thc_efct_memfd;
-  /* byte offset in thc_efct_memfd of the next hugepage to allocate */
-  off_t                 thc_efct_memfd_off;
-
+  struct oo_hugetlb_allocator* thc_efct_alloc;
   /* backing store for packet buffers */
   struct oo_hugetlb_allocator* thc_pktbuf_alloc;
 

--- a/src/include/onload/tcp_helper_fns.h
+++ b/src/include/onload/tcp_helper_fns.h
@@ -261,6 +261,9 @@ extern int efab_tcp_helper_efct_superbuf_config_refresh(
                                         tcp_helper_resource_t* trs,
                                         oo_efct_superbuf_config_refresh_t* op);
 
+extern int efab_tcp_helper_pkt_buf_map(tcp_helper_resource_t* trs,
+                                       oo_pkt_buf_map_t* arg);
+
 extern void
 tcp_helper_cluster_ref(tcp_helper_cluster_t* thc);
 
@@ -282,6 +285,7 @@ tcp_helper_cluster_dump(tcp_helper_resource_t* thr, void* buf, int buf_len);
 extern int tcp_helper_cluster_alloc_thr(const char* name,
                                         int cluster_size,
                                         int cluster_restart,
+                                        int pktbuf_memfd,
                                         int ni_flags,
                                         const ci_netif_config_opts* ni_opts,
                                         tcp_helper_resource_t** thr_out);

--- a/src/lib/ciul/efct_vi.c
+++ b/src/lib/ciul/efct_vi.c
@@ -1186,17 +1186,6 @@ int efct_vi_find_free_rxq(ef_vi* vi, int qid)
 }
 
 #ifndef __KERNEL__
-/* These definitions are needed to be able to build on old distros, but we
- * have them on new builds too so that we get 'free' checking that they're
- * the correct values */
-#define MFD_CLOEXEC 1U
-#define MFD_HUGETLB 4U
-#if defined __x86_64__
-#define __NR_memfd_create 319
-#elif defined __aarch64__
-#define __NR_memfd_create 279
-#endif
-
 int efct_vi_attach_rxq(ef_vi* vi, int qid, unsigned n_superbufs)
 {
   int rc;
@@ -1216,9 +1205,12 @@ int efct_vi_attach_rxq(ef_vi* vi, int qid, unsigned n_superbufs)
   }
 
   /* The kernel code can cope with no memfd being provided, but only on older
-   * kernels. MFD_HUGETLB is available in >=4.14 (after memfd_create() itself
-   * in >=3.17). The fallback employs efrm_find_ksym(), so stopped working in
-   * >=5.7. Plenty of overlap. */
+   * kernels, i.e. older than 5.7 where the fallback with efrm_find_ksym()
+   * stopped working. Overall:
+   * - Onload uses the efrm_find_ksym() fallback on Linux older than 4.14.
+   * - Both efrm_find_ksym() and memfd_create(MFD_HUGETLB) are available
+   *   on Linux between 4.14 and 5.7.
+   * - Onload can use only memfd_create(MFD_HUGETLB) on Linux 5.7+. */
   {
     char name[32];
     snprintf(name, sizeof(name), "ef_vi:%d", qid);

--- a/src/lib/ciul/efct_vi.c
+++ b/src/lib/ciul/efct_vi.c
@@ -1258,7 +1258,6 @@ int efct_vi_attach_rxq(ef_vi* vi, int qid, unsigned n_superbufs)
   ra.u.rxq.in_n_hugepages = n_hugepages;
   ra.u.rxq.in_timestamp_req = true;
   ra.u.rxq.in_memfd = mfd;
-  ra.u.rxq.in_memfd_off = 0;
   rc = ci_resource_alloc(vi->dh, &ra);
   if( mfd >= 0 )
     close(mfd);

--- a/src/lib/ciul/pt_endpoint.c
+++ b/src/lib/ciul/pt_endpoint.c
@@ -370,7 +370,7 @@ void ef_vi_set_intf_ver(char* intf_ver, size_t len)
    * It'd also be possible to enhance the checksum computation to be smarter
    * (e.g. by ignoring comments, etc.).
    */
-  if( strcmp(EFCH_INTF_VER, "ea698a312106f6a40f18ca0a1336390d") ) {
+  if( strcmp(EFCH_INTF_VER, "a29c28976c88c0568a2131c90ccfc35d") ) {
     fprintf(stderr, "ef_vi: ERROR: char interface has changed\n");
     abort();
   }

--- a/src/lib/efhw/efct.c
+++ b/src/lib/efhw/efct.c
@@ -45,7 +45,8 @@ static void efct_check_for_flushes(struct work_struct *work);
 
 int
 efct_nic_rxq_bind(struct efhw_nic *nic, int qid, bool timestamp_req,
-                  size_t n_hugepages, struct file* memfd, off_t* memfd_off,
+                  size_t n_hugepages,
+                  struct oo_hugetlb_allocator *hugetlb_alloc,
                   struct efab_efct_rxq_uk_shm_q *shm,
                   unsigned wakeup_instance, struct efhw_efct_rxq *rxq)
 {
@@ -66,12 +67,12 @@ efct_nic_rxq_bind(struct efhw_nic *nic, int qid, bool timestamp_req,
      * check as well */
     return -EINVAL;
   }
-  efct_provide_bind_memfd(memfd, *memfd_off);
+  efct_provide_hugetlb_alloc(hugetlb_alloc);
   EFCT_PRE(dev, edev, cli, nic, rc);
 
   rc = __efct_nic_rxq_bind(edev, cli, &qparams, nic->arch_extra, n_hugepages, shm, wakeup_instance, rxq);
   EFCT_POST(dev, edev, cli, nic, rc);
-  efct_unprovide_bind_memfd(memfd_off);
+  efct_unprovide_hugetlb_alloc();
   return rc;
 }
 

--- a/src/lib/efhw/efct.h
+++ b/src/lib/efhw/efct.h
@@ -5,6 +5,8 @@
 #define LIB_EFHW_EFCT_H
 
 struct efct_client;
+struct oo_hugetlb_allocator;
+
 static inline struct efct_client*
 efhw_nic_acquire_efct_device(struct efhw_nic* nic)
 {
@@ -53,8 +55,8 @@ efhw_nic_release_efct_device(struct efhw_nic* nic,
   put_device((dev)); \
 }
 
-void efct_provide_bind_memfd(struct file* memfd, off_t memfd_off);
-void efct_unprovide_bind_memfd(off_t *final_off);
+void efct_provide_hugetlb_alloc(struct oo_hugetlb_allocator *hugetlb_alloc);
+void efct_unprovide_hugetlb_alloc(void);
 
 #endif
 

--- a/src/lib/efrm/efrm_efct_rxq.c
+++ b/src/lib/efrm/efrm_efct_rxq.c
@@ -78,7 +78,7 @@ int efrm_rxq_alloc(struct efrm_vi *vi, int qid, int shm_ix, bool timestamp_req,
 	rc = efct_nic_rxq_bind(vi_rs->rs_client->nic, qid, timestamp_req,
 	                       n_hugepages, memfd, memfd_off,
 	                       &vi->efct_shm->q[shm_ix], vi->rs.rs_instance,
-						   &rxq->hw);
+	                       &rxq->hw);
 	if (rc < 0) {
 		kfree(rxq);
 		return rc;

--- a/src/lib/efrm/efrm_efct_rxq.c
+++ b/src/lib/efrm/efrm_efct_rxq.c
@@ -54,7 +54,8 @@ EXPORT_SYMBOL(efrm_rxq_from_resource);
 
 
 int efrm_rxq_alloc(struct efrm_vi *vi, int qid, int shm_ix, bool timestamp_req,
-                   size_t n_hugepages, struct file* memfd, off_t* memfd_off,
+                   size_t n_hugepages,
+                   struct oo_hugetlb_allocator *hugetlb_alloc,
                    struct efrm_efct_rxq **rxq_out)
 {
 #if CI_HAVE_EFCT_AUX
@@ -67,7 +68,7 @@ int efrm_rxq_alloc(struct efrm_vi *vi, int qid, int shm_ix, bool timestamp_req,
 
 	if (shm_ix < 0 ||
 	    shm_ix >= efhw_nic_max_shared_rxqs(vi_rs->rs_client->nic) ||
-	    memfd_off < 0 )
+	    !hugetlb_alloc)
 		return -EINVAL;
 
 	rxq = kzalloc(sizeof(struct efrm_efct_rxq), GFP_KERNEL);
@@ -76,7 +77,7 @@ int efrm_rxq_alloc(struct efrm_vi *vi, int qid, int shm_ix, bool timestamp_req,
 
 	rxq->vi = vi;
 	rc = efct_nic_rxq_bind(vi_rs->rs_client->nic, qid, timestamp_req,
-	                       n_hugepages, memfd, memfd_off,
+	                       n_hugepages, hugetlb_alloc,
 	                       &vi->efct_shm->q[shm_ix], vi->rs.rs_instance,
 	                       &rxq->hw);
 	if (rc < 0) {

--- a/src/lib/efthrm/iobufset.c
+++ b/src/lib/efthrm/iobufset.c
@@ -320,6 +320,7 @@ static int oo_bufpage_alloc(struct oo_buffer_pages **pages_out,
   }
   if( *flags & OO_IOBUFSET_FLAG_HUGE_PAGE_FORCE ) {
     ci_assert_equal(low_order, HPAGE_SHIFT - PAGE_SHIFT);
+    oo_iobufset_kfree(pages);
     return -ENOMEM;
   }
 #endif

--- a/src/lib/efthrm/iobufset.c
+++ b/src/lib/efthrm/iobufset.c
@@ -499,10 +499,10 @@ oo_iobufset_resource_alloc(struct oo_buffer_pages * pages, struct efrm_pd *pd,
   }
 
   rc = efrm_pd_dma_map(iobrs->pd, pages->n_bufs,
-		       nic_order,
-		       addrs, iobrs->dma_addrs, iobrs->free_addrs,
-		       hw_addrs, sizeof(hw_addrs[0]),
-		       put_user_fake, &iobrs->buf_tbl_alloc, reset_pending, page_order);
+                       nic_order,
+                       addrs, iobrs->dma_addrs, iobrs->free_addrs,
+                       hw_addrs, sizeof(hw_addrs[0]),
+                       put_user_fake, &iobrs->buf_tbl_alloc, reset_pending, page_order);
   kfree(addrs);
 
   if( rc < 0 )

--- a/src/lib/efthrm/tcp_helper_endpoint_move.c
+++ b/src/lib/efthrm/tcp_helper_endpoint_move.c
@@ -793,6 +793,7 @@ int efab_tcp_loopback_connect(ci_private_t *priv, void *arg)
          * todo: no hardware interfaces are necessary */
         strcpy(alloc.in_version, onload_short_version);
         strcpy(alloc.in_uk_intf_ver, oo_uk_intf_ver);
+        alloc.in_pktbuf_memfd = -1;
 
         /* There will be no more active connections in the new stack
          * - tcp_shared_local_ports is useless. */

--- a/src/lib/efthrm/tcp_helper_ioctl.c
+++ b/src/lib/efthrm/tcp_helper_ioctl.c
@@ -999,6 +999,14 @@ oo_efct_superbuf_config_refresh_rsop(ci_private_t *priv, void *op)
 }
 
 static int
+oo_pkt_buf_map_rsop(ci_private_t* priv, void *arg)
+{
+  if (priv->thr == NULL)
+    return -EINVAL;
+  return efab_tcp_helper_pkt_buf_map(priv->thr, arg);
+}
+
+static int
 oo_eplock_lock_rsop(ci_private_t* priv, void* arg)
 {
   long timeout_jiffies = MAX_SCHEDULE_TIMEOUT;
@@ -1688,6 +1696,7 @@ oo_operations_table_t oo_operations[] = {
 
   op(OO_IOC_AF_XDP_KICK, oo_af_xdp_kick_rsop),
   op(OO_IOC_EFCT_SUPERBUF_CONFIG_REFRESH,oo_efct_superbuf_config_refresh_rsop),
+  op(OO_IOC_PKT_BUF_MMAP, oo_pkt_buf_map_rsop),
 
 /* Here come non contigous operations only, their position need to match
  * index according to their placeholder */

--- a/src/lib/efthrm/tcp_helper_resource.c
+++ b/src/lib/efthrm/tcp_helper_resource.c
@@ -1002,7 +1002,7 @@ int tcp_helper_post_filter_add(tcp_helper_resource_t* trs, int hwport,
                         trs->thc_efct_memfd, &trs->thc_efct_memfd_off,
                         &trs->nic[intf_i].thn_efct_rxq[qix]);
     if( rc < 0 ) {
-      ci_log("%s: ERROR: efrm_rxq_alloc failed (%d)\n", __func__, rc);
+      ci_log("%s: ERROR: efrm_rxq_alloc failed (%d)", __func__, rc);
       return rc;
     }
     efct_vi_start_rxq(vi, qix);
@@ -2539,9 +2539,9 @@ allocate_netif_resources(ci_resource_onload_alloc_t* alloc,
   /* The shared netif-state buffer and EP buffers are part of the mem mmap */
   trs->mem_mmap_bytes += ns->netif_mmap_bytes;
   OO_DEBUG_MEMSIZE(ci_log(
-	"added %d (0x%x) bytes for shared netif state and ep buffers, "
-	"reached %d (0x%x)", ns->netif_mmap_bytes, ns->netif_mmap_bytes,
-	trs->mem_mmap_bytes, trs->mem_mmap_bytes));
+        "added %d (0x%x) bytes for shared netif state and ep buffers, "
+        "reached %d (0x%x)", ns->netif_mmap_bytes, ns->netif_mmap_bytes,
+        trs->mem_mmap_bytes, trs->mem_mmap_bytes));
 
   if( trs->name[0] == '\0' )
     snprintf(ns->pretty_name, sizeof(ns->pretty_name), "%d", ns->stack_id);
@@ -3196,7 +3196,7 @@ static int oo_get_nics(tcp_helper_resource_t* trs, int ifindices_len)
   if( trs->netif.nic_n == 0 && ifindices_len != 0 ) {
     ci_log("%s: ERROR: No Solarflare network interfaces are active/UP,\n"
            "or they are configured with packed stream firmware, disabled,\n"
-	   "or unlicensed for Onload. Please check your configuration.",
+           "or unlicensed for Onload. Please check your configuration.",
            __FUNCTION__);
     return -ENODEV;
   }

--- a/src/lib/kernel_utils/hugetlb.c
+++ b/src/lib/kernel_utils/hugetlb.c
@@ -1,0 +1,271 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+/* X-SPDX-Copyright-Text: (c) Copyright 2023 Advanced Micro Devices, Inc. */
+
+#include <linux/hugetlb.h>
+#include <linux/mman.h>
+#include <uapi/linux/falloc.h>
+#include <kernel_utils/hugetlb.h>
+#include <ci/driver/kernel_compat.h> /* For pin_user_pages(). */
+#include <ci/efrm/sysdep.h> /* For efrm_find_ksym(). */
+
+#ifdef EFRM_HAVE_NEW_KALLSYMS
+/*
+ * oo_hugetlb_file_setup - Create a pseudo hugetlb file.
+ *
+ * This fallback only exists on old kernels, but that's fine: new kernels
+ * all have memfd_create, and there's considerable overlap between 'old'
+ * and 'new' (e.g. RHEL8) so we can deal with potential oddballs.
+ *
+ * Return:
+ *   A file struct on success or an error code.
+ */
+static struct file *oo_hugetlb_file_setup(void)
+{
+	static __typeof__(hugetlb_file_setup)* fn_hugetlb_file_setup;
+
+	if (!fn_hugetlb_file_setup)
+		fn_hugetlb_file_setup = efrm_find_ksym("hugetlb_file_setup");
+
+	if (fn_hugetlb_file_setup) {
+		struct user_struct* user;
+		return fn_hugetlb_file_setup(HUGETLB_ANON_FILE,
+				OO_HUGEPAGE_SIZE, 0, &user,
+				HUGETLB_ANONHUGE_INODE,
+				ilog2(OO_HUGEPAGE_SIZE));
+	}
+
+	return ERR_PTR(-ENOSYS);
+}
+#else
+static struct file *oo_hugetlb_file_setup(void)
+{
+	return ERR_PTR(-ENOSYS);
+}
+#endif
+
+
+static struct oo_hugetlb_allocator *
+do_hugetlb_allocator_create(struct file *filp)
+{
+	struct oo_hugetlb_allocator *allocator;
+
+	/* This assertion and others in this file should probably become a
+	 * user-friendly EINVAL as a return value, but since hugetlb is an
+	 * internal library with limited use, doing assertions for now. */
+	EFRM_ASSERT(filp);
+
+	allocator = kmalloc(sizeof(*allocator), GFP_KERNEL);
+	if (!allocator) {
+		return ERR_PTR(-ENOMEM);
+	}
+
+	allocator->filp = filp;
+	allocator->offset = 0;
+	atomic_set(&allocator->refcnt, 1);
+
+	return allocator;
+}
+
+struct oo_hugetlb_allocator *oo_hugetlb_allocator_create(int fd)
+{
+	struct oo_hugetlb_allocator *allocator;
+	struct file *filp;
+	int rc;
+
+	/* Either use the given (memfd) file or try create a new pseudo file.*/
+	if (fd >= 0) {
+		filp = fget(fd);
+		if (!filp) {
+			rc = -EINVAL;
+			goto fail_setup;
+		}
+	} else {
+		filp = oo_hugetlb_file_setup();
+		if (IS_ERR(filp)) {
+			rc = PTR_ERR(filp);
+			goto fail_setup;
+		}
+	}
+
+	/* Call the allocator constructor with the set up file. */
+	allocator = do_hugetlb_allocator_create(filp);
+	if (IS_ERR(allocator)) {
+		rc = PTR_ERR(allocator);
+		goto fail_alloc;
+	}
+
+	return allocator;
+
+fail_alloc:
+	fput(filp);
+
+fail_setup:
+	allocator = ERR_PTR(rc);
+	return allocator;
+}
+EXPORT_SYMBOL(oo_hugetlb_allocator_create);
+
+struct oo_hugetlb_allocator *
+oo_hugetlb_allocator_get(struct oo_hugetlb_allocator *allocator)
+{
+	EFRM_ASSERT(allocator);
+	EFRM_ASSERT(atomic_read(&allocator->refcnt) > 0);
+
+	atomic_inc(&allocator->refcnt);
+
+	return allocator;
+}
+EXPORT_SYMBOL(oo_hugetlb_allocator_get);
+
+void oo_hugetlb_allocator_put(struct oo_hugetlb_allocator *allocator)
+{
+	EFRM_ASSERT(allocator);
+	EFRM_ASSERT(allocator->filp);
+
+	if (atomic_dec_and_test(&allocator->refcnt)) {
+		fput(allocator->filp);
+		kfree(allocator);
+	}
+}
+EXPORT_SYMBOL(oo_hugetlb_allocator_put);
+
+int
+oo_hugetlb_page_alloc_raw(struct oo_hugetlb_allocator *allocator,
+		struct file **filp_out, struct page **page_out)
+{
+	struct inode* inode;
+	unsigned long addr;
+	int rc;
+
+	EFRM_ASSERT(allocator);
+	EFRM_ASSERT(allocator->filp);
+	EFRM_ASSERT(filp_out);
+	EFRM_ASSERT(page_out);
+
+	*filp_out = get_file(allocator->filp);
+
+	/* Allocate one huge page at the current allocator's offset. */
+	inode = file_inode(allocator->filp);
+	if (i_size_read(inode) < allocator->offset + OO_HUGEPAGE_SIZE) {
+		rc = (int)vfs_truncate(&allocator->filp->f_path,
+				allocator->offset + OO_HUGEPAGE_SIZE);
+		if (rc < 0) {
+			EFRM_ERR("%s: ftruncate() failed: %d", __func__, rc);
+			goto fail_vfs;
+		}
+	}
+
+	rc = vfs_fallocate(allocator->filp, 0, allocator->offset,
+			OO_HUGEPAGE_SIZE);
+	if (rc < 0) {
+		EFRM_ERR("%s: fallocate() failed: %d", __func__, rc);
+		goto fail_vfs;
+	}
+
+	/* Get the user address on behalf of the current process so we could
+	 * call pin_user_pages(). Alternatively, we could find_get_page()
+	 * without mapping, but this would not migrate a page from a
+	 * potentially movable zone as the hugepages may be allocated with
+	 * GFP_HIGHUSER_MOVABLE. */
+	addr = vm_mmap(*filp_out, 0, OO_HUGEPAGE_SIZE, PROT_READ | PROT_WRITE,
+			MAP_SHARED | MAP_HUGETLB | MAP_HUGE_2MB,
+			allocator->offset);
+
+	if (IS_ERR((void*)addr)) {
+		rc = PTR_ERR((void*)addr);
+		goto fail_vfs;
+	}
+
+	mmap_read_lock(current->mm);
+	rc = pin_user_pages(addr, 1, FOLL_WRITE, page_out, NULL);
+	mmap_read_unlock(current->mm);
+
+	vm_munmap(addr, OO_HUGEPAGE_SIZE);
+
+	/* Did we get a good hugepage? */
+	if (rc != 1) {
+		EFRM_ERR("%s: Unable to pin page at 0x%08lx rc=%d", __func__,
+				allocator->offset, rc);
+		goto fail_vfs;
+	}
+
+	if (!(*page_out)) {
+		EFRM_ERR("%s: Unable to create hugepage at 0x%08lx", __func__,
+				allocator->offset);
+		rc = -ENOMEM;
+		goto fail_vfs;
+	}
+
+	/* memfd originated in userspace, so we have to check we actually
+	 * got what we thought we would. */
+	if (!PageHuge(*page_out) || PageTail(*page_out)) {
+		EFRM_ERR("%s: hugepage was badly created (0x%08lx / %d / %d)",
+				__func__, (*page_out)->index * OO_HUGEPAGE_SIZE,
+				PageHuge(*page_out), PageTail(*page_out));
+		rc = -ENOMEM;
+		goto fail_check;
+	}
+
+	EFRM_ASSERT(page_maybe_dma_pinned(*page_out));
+
+	allocator->offset = allocator->offset + OO_HUGEPAGE_SIZE;
+
+	return 0;
+
+fail_check:
+	unpin_user_page(*page_out);
+
+fail_vfs:
+	*page_out = NULL;
+
+	fput(*filp_out);
+	*filp_out = NULL;
+
+	return rc;
+}
+EXPORT_SYMBOL(oo_hugetlb_page_alloc_raw);
+
+void oo_hugetlb_page_free_raw(struct file *filp, struct page *page)
+{
+	off_t offset;
+	int rc;
+
+	EFRM_ASSERT(filp);
+	EFRM_ASSERT(page);
+
+	offset = page->index * OO_HUGEPAGE_SIZE;
+
+	unpin_user_page(page);
+	rc = vfs_fallocate(filp, FALLOC_FL_PUNCH_HOLE | FALLOC_FL_KEEP_SIZE,
+			offset, OO_HUGEPAGE_SIZE);
+	if (rc)
+		EFRM_WARN("%s: vfs_fallocate() failed: %d", __func__, rc);
+
+	fput(filp);
+}
+EXPORT_SYMBOL(oo_hugetlb_page_free_raw);
+
+int
+oo_hugetlb_pages_prealloc(struct oo_hugetlb_allocator *allocator,
+		int nr_pages)
+{
+	struct inode* inode;
+	int rc;
+
+	EFRM_ASSERT(allocator);
+	EFRM_ASSERT(!allocator->offset);
+
+	inode = file_inode(allocator->filp);
+	if (i_size_read(inode) < nr_pages * OO_HUGEPAGE_SIZE) {
+		rc = (int)vfs_truncate(&allocator->filp->f_path,
+				nr_pages * OO_HUGEPAGE_SIZE);
+		if (rc < 0) {
+			EFRM_ERR("%s: ftruncate() failed: %d", __func__, rc);
+			return rc;
+		}
+	}
+
+	return vfs_fallocate(allocator->filp, 0, 0,
+			nr_pages * OO_HUGEPAGE_SIZE);
+}
+EXPORT_SYMBOL(oo_hugetlb_pages_prealloc);

--- a/src/lib/transport/ip/netif_init.c
+++ b/src/lib/transport/ip/netif_init.c
@@ -488,8 +488,8 @@ void ci_netif_config_opts_defaults(ci_netif_config_opts* opts)
 # undef  CI_CFG_OPTGROUP
 # undef  CI_CFG_OPT
 # undef  CI_CFG_STR_OPT
-# define CI_CFG_OPT(env, name, type, doc, type_modifider, group,     \
-                    default, minimum, maximum, presentation)	      \
+# define CI_CFG_OPT(env, name, type, doc, type_modifider, group,       \
+                    default, minimum, maximum, presentation)           \
   opts->name = default;
 
 # define CI_CFG_STR_OPT(env, name, type, doc, type_modifider, group,   \
@@ -595,13 +595,13 @@ void ci_netif_config_opts_rangecheck(ci_netif_config_opts* opts)
 #define CI_CFG_STR_OPT(...)
 
 #define CI_CFG_OPT(env, name, type, doc, bits, group, default, minimum, maximum, pres) \
-{ type _val = opts->name;					          \
-  type _max;								  \
-  type _min;								  \
+{ type _val = opts->name;                                                 \
+  type _max;                                                              \
+  type _min;                                                              \
   _optbits=sizeof(type)*8;                                                \
-  _bitwidth=_CI_CFG_BITVAL##bits;					  \
+  _bitwidth=_CI_CFG_BITVAL##bits;                                         \
   MIN = 0;                                                                \
-  MAX = ((1ull<<(_bitwidth-1))<<1) - 1ull;       			  \
+  MAX = ((1ull<<(_bitwidth-1))<<1) - 1ull;                                \
   SMAX = MAX >> 1; SMIN = -SMAX-1;                                        \
   _max = (type)(maximum); /* try to stop the compiler warning */          \
   _min = (type)(minimum); /* about silly comparisons          */          \
@@ -2474,7 +2474,7 @@ netif_tcp_helper_alloc_u(ef_driver_handle fd, ci_netif* ni,
    */
   ni->nic_set = ra.out_nic_set;
   LOG_NC(ci_log("%s: nic set %" EFRM_NIC_SET_FMT, __FUNCTION__,
-	                efrm_nic_set_pri_arg(&ni->nic_set)));
+                efrm_nic_set_pri_arg(&ni->nic_set)));
   ni->mmap_bytes = ra.out_netif_mmap_bytes;
 
   /****************************************************************************
@@ -2502,7 +2502,7 @@ netif_tcp_helper_alloc_u(ef_driver_handle fd, ci_netif* ni,
 
   if( ns->flags & CI_NETIF_FLAG_ONLOAD_UNSUPPORTED ) {
     ci_log("*** Warning: use of %s with this adapter is likely",
-	   onload_product);
+           onload_product);
     ci_log("***  to show suboptimal performance for all cases other than the");
     ci_log("***  most trivial benchmarks.  Please see your Solarflare");
     ci_log("***  representative/reseller to obtain an Onload-capable");

--- a/src/lib/transport/ip/netif_init.c
+++ b/src/lib/transport/ip/netif_init.c
@@ -2367,14 +2367,6 @@ ci_inline void netif_tcp_helper_free(ci_netif* ni)
   ci_netif_deinit(ni);
 }
 
-#define MFD_CLOEXEC 1U
-#define MFD_HUGETLB 4U
-#if defined __x86_64__
-#define __NR_memfd_create 319
-#elif defined __aarch64__
-#define __NR_memfd_create 279
-#endif
-
 static void init_resource_alloc(ci_resource_onload_alloc_t* ra,
                                 const ci_netif_config_opts* opts,
                                 unsigned flags, const char* name)
@@ -2398,8 +2390,15 @@ static void init_resource_alloc(ci_resource_onload_alloc_t* ra,
 
   ra->in_efct_memfd = -1;
   ra->in_pktbuf_memfd = -1;
-  /* The kernel code can cope with no memfd being provided, but only on older
-   * kernels */
+
+  /* The kernel code can cope with no memfd being provided in both cases
+   * (in_efct_memfd and in_pktbuf_memfd), but only on older kernels, i.e.
+   * older than 5.7 where the fallback with efrm_find_ksym() stopped working.
+   * Overall:
+   * - Onload uses the efrm_find_ksym() fallback on Linux older than 4.14.
+   * - Both efrm_find_ksym() and memfd_create(MFD_HUGETLB) are available
+   *   on Linux between 4.14 and 5.7.
+   * - Onload can use only memfd_create(MFD_HUGETLB) on Linux 5.7+. */
   {
     char mfd_name[CI_CFG_STACK_NAME_LEN + 8];
     snprintf(mfd_name, sizeof(mfd_name), "efct/%s", name);

--- a/src/lib/transport/ip/netif_init.c
+++ b/src/lib/transport/ip/netif_init.c
@@ -2370,6 +2370,13 @@ ci_inline void netif_tcp_helper_free(ci_netif* ni)
   ci_netif_deinit(ni);
 }
 
+#define MFD_CLOEXEC 1U
+#define MFD_HUGETLB 4U
+#if defined __x86_64__
+#define __NR_memfd_create 319
+#elif defined __aarch64__
+#define __NR_memfd_create 279
+#endif
 
 static void init_resource_alloc(ci_resource_onload_alloc_t* ra,
                                 const ci_netif_config_opts* opts,
@@ -2393,17 +2400,16 @@ static void init_resource_alloc(ci_resource_onload_alloc_t* ra,
     strncpy(ra->in_name, name, CI_CFG_STACK_NAME_LEN);
 
   ra->in_memfd = -1;
-#ifdef MFD_HUGETLB
   /* The kernel code can cope with no memfd being provided, but only on older
    * kernels */
   {
     char mfd_name[CI_CFG_STACK_NAME_LEN + 8];
     snprintf(mfd_name, sizeof(mfd_name), "efct/%s", name);
-    ra->in_memfd = memfd_create(mfd_name, MFD_CLOEXEC | MFD_HUGETLB);
+    ra->in_memfd = syscall(__NR_memfd_create, mfd_name,
+                           MFD_CLOEXEC | MFD_HUGETLB);
     if( ra->in_memfd < 0 && errno != ENOSYS )
       LOG_S(ci_log("%s: memfd_create failed %d", __FUNCTION__, errno));
   }
-#endif
 }
 
 


### PR DESCRIPTION
This series introduces the new hugetlb library to allocate mappable 2MiB hugepages in the kernel. The key features:

* Better Linux 6.1 support: the new hugetlb library uses the EFCT approach that doesn't require VMA workarounds broken in 6.1.
* Code deduplication: Onload used to have packet buffers and EFCT doing the same thing... differently.
* Use of `pin_user_pages()` instead of `find_get_page()` as suggested in https://lkml.org/lkml/2023/4/11/1286.
* New IOCTL to map packet buffers.

Please see more details in the commit messages.