### PR TITLE
Fix Onload build for Linux 6.3

### DIFF
--- a/src/driver/linux_char/mmap.c
+++ b/src/driver/linux_char/mmap.c
@@ -127,7 +127,7 @@ ci_char_fop_mmap(struct file* file, struct vm_area_struct* vma)
   if( (rc = efch_resource_id_lookup(rsid, &priv->rt, &rs)) < 0 )
     return rc;
 
-  vma->vm_flags |= EFRM_VM_BASE_FLAGS;
+  vm_flags_set(vma, EFRM_VM_BASE_FLAGS);
 
   /* Hook into the VM so we can keep a proper reference count on this
   ** resource.

--- a/src/driver/linux_char/mmap_iopage.c
+++ b/src/driver/linux_char/mmap_iopage.c
@@ -30,7 +30,7 @@ ci_mmap_io(struct efhw_nic* nic, resource_size_t page_addr, size_t len,
   ci_assert((*offset &~ CI_PAGE_MASK) == 0);
   ci_assert(*map_num == 0 || *offset > 0);
 
-  vma->vm_flags |= EFRM_VM_IO_FLAGS;
+  vm_flags_set(vma, EFRM_VM_IO_FLAGS);
 
   if( set_wc )
     vma->vm_page_prot = pgprot_writecombine(vma->vm_page_prot);

--- a/src/driver/linux_char/vi_resource_mmap.c
+++ b/src/driver/linux_char/vi_resource_mmap.c
@@ -219,7 +219,8 @@ efab_vi_rm_mmap_rxq_shm(struct efrm_vi *virs, unsigned long *bytes,
   if( rc < 0 )
     EFCH_ERR("%s: ERROR: remap_vmalloc_range failed rc=%d", __func__, rc);
   else {
-    vma->vm_flags &= ~VM_DONTDUMP; /* remap_vmalloc_range_partial sets this */
+    /* remap_vmalloc_range_partial sets this */
+    vm_flags_clear(vma, VM_DONTDUMP);
     *bytes -= len;
     *offset += len;
   }

--- a/src/driver/linux_onload/epoll_device.c
+++ b/src/driver/linux_onload/epoll_device.c
@@ -643,7 +643,7 @@ static int oo_epoll1_mmap(struct oo_epoll1_private* priv,
     return -EINVAL;
   if (vma->vm_flags & VM_WRITE)
     return -EPERM;
-  vma->vm_flags &= ~VM_MAYWRITE;
+  vm_flags_clear(vma, VM_MAYWRITE);
 
   /* Map memory to user */
   if( priv->page == NULL ||

--- a/src/driver/linux_onload/mmap.c
+++ b/src/driver/linux_onload/mmap.c
@@ -543,7 +543,7 @@ oo_stack_mmap(ci_private_t* priv, struct vm_area_struct* vma)
 
   ci_assert((offset & PAGE_MASK) == offset);
 
-  vma->vm_flags |= EFRM_VM_BASE_FLAGS;
+  vm_flags_set(vma, EFRM_VM_BASE_FLAGS);
   vma->vm_private_data = (void *) priv->thr;
 
   vma->vm_ops = &vm_ops;
@@ -575,7 +575,7 @@ oo_fop_mmap(struct file* file, struct vm_area_struct* vma)
 
   /* We never turn read-only mmaps into read-write.  Forbid it. */
   if( ! (vma->vm_flags & VM_WRITE) )
-    vma->vm_flags &= ~VM_MAYWRITE;
+    vm_flags_clear(vma, VM_MAYWRITE);
 
   switch( map_type ) {
   case OO_MMAP_TYPE_NETIF:

--- a/src/driver/linux_onload/onload_internal.h
+++ b/src/driver/linux_onload/onload_internal.h
@@ -44,7 +44,7 @@ oo_cplane_empower_cap_net_raw(struct net* netns, struct cred **my_creds_p)
 #endif
     struct cred *creds = prepare_creds();
     if( creds != NULL ) {
-      creds->cap_effective.cap[0] |= 1 << CAP_NET_RAW;
+      cap_raise(creds->cap_effective, CAP_NET_RAW);
       *my_creds_p = creds;
       return override_creds(creds);
     }

--- a/src/driver/linux_onload/oo_shmbuf.c
+++ b/src/driver/linux_onload/oo_shmbuf.c
@@ -115,6 +115,7 @@ int oo_shmbuf_fault(struct oo_shmbuf* sh, struct vm_area_struct* vma,
   rc = oo_remap_vmalloc_range_partial(vma, vma->vm_start + start_off,
                                       (void*)sh->addrs[i], size);
   if( rc >= 0 )
-    vma->vm_flags &= ~VM_DONTDUMP; /* remap_vmalloc_range_partial sets this */
+    /* remap_vmalloc_range_partial sets this */
+    vm_flags_clear(vma, VM_DONTDUMP);
   return rc;
 }

--- a/src/driver/linux_resource/kernel_compat.sh
+++ b/src/driver/linux_resource/kernel_compat.sh
@@ -155,6 +155,8 @@ EFRM_HAVE_ITER_UBUF symbol ITER_UBUF include/linux/uio.h
 EFRM_HAVE_FLOW_RSS      symbol  FLOW_RSS    include/uapi/linux/ethtool.h
 
 EFRM_CLASS_DEVNODE_DEV_IS_CONST memtype struct_class devnode include/linux/device/class.h char*(*)(const struct device *, umode_t *)
+
+EFRM_HAVE_VM_FLAGS_SET symbol vm_flags_set include/linux/mm.h
 # TODO move onload-related stuff from net kernel_compat
 " | egrep -v -e '^#' -e '^$' | sed 's/[ \t][ \t]*/:/g'
 }

--- a/src/include/ci/driver/kernel_compat.h
+++ b/src/include/ci/driver/kernel_compat.h
@@ -421,4 +421,16 @@ oo_remap_vmalloc_range_partial(struct vm_area_struct *vma, unsigned long uaddr,
 #define ci_netif_rx_non_irq netif_rx
 #endif /* EFRM_HAVE_NETIF_RX_NI */
 
+#ifndef EFRM_HAVE_VM_FLAGS_SET
+/* Linux < 6.3 */
+static inline void vm_flags_set(struct vm_area_struct *vma, vm_flags_t flags)
+{
+  vma->vm_flags |= flags;
+}
+static inline void vm_flags_clear(struct vm_area_struct *vma, vm_flags_t flags)
+{
+  vma->vm_flags &= ~flags;
+}
+#endif /* EFRM_HAVE_VM_FLAGS_SET */
+
 #endif /* DRIVER_LINUX_RESOURCE_KERNEL_COMPAT_H */


### PR DESCRIPTION
Compatibility patches for Linux 6.3.
Fix errors:
```
build/x86_64_linux-6.3.0-1.el8.elrepo.x86_64/driver/linux_char/mmap_iopage.c: In function ‘ci_mmap_io’:
build/x86_64_linux-6.3.0-1.el8.elrepo.x86_64/driver/linux_char/mmap_iopage.c:33:17: error: assignment of read-only member ‘vm_flags’
   vma->vm_flags |= EFRM_VM_IO_FLAGS;
                 ^~
```
and
```
build/x86_64_linux-6.3.0-1.el9.elrepo.x86_64/driver/linux_onload/onload_internal.h: In function ‘oo_cplane_empower_cap_net_raw’:
build/x86_64_linux-6.3.0-1.el9.elrepo.x86_64/driver/linux_onload/onload_internal.h:47:27: error: ‘kernel_cap_t’ has no member named ‘cap’
   47 |       creds->cap_effective.cap[0] |= 1 << CAP_NET_RAW;
      |   
```

With the patches build works (checked on CentOS 9):
```
make -C build/x86_64_linux-6.3.0-1.el9.elrepo.x86_64/ -j6
make -C build/x86_64_linux-5.14.0-247.el9.x86_64/ -j6
```