### PR TITLE
unload.sh: use the exact process name to kill it

### DIFF
--- a/src/driver/linux/unload.sh
+++ b/src/driver/linux/unload.sh
@@ -60,7 +60,7 @@ dochar () {
 
   # onload_helper is spawned from UL, so kernel does not have a list of
   # them.  Let's kill them by name!
-  pkill '\<onload_helper\>'
+  pkill -x onload_helper
 
   modusedby sfc_resource sfc_affinity &&
     tryunload sfc_affinity


### PR DESCRIPTION
This will avoid the following warning messages from pkill version 4.0: "pkill: pattern that searches for process name longer than 15 characters will result in zero matches
Try `pkill -f' option to match against the complete command line."

Using the -f option in this case is unnecessary, since it implies searching for a template in the program parameters: it will kill, for example, the process 'vim onload_helper'.

-------
Checked on Deb12 and Ubu23.04 (with pkill v.4). Before this patch, the following command line shows the error:
```shell
$ sudo ./build/x86_64_linux-6.1.0-9-amd64/driver/linux/unload.sh 
pkill: pattern that searches for process name longer than 15 characters will result in zero matches
Try `pkill -f' option to match against the complete command line.
```
Note: this warning is related to the changes in pkill: https://github.com/warmchang/procps/commit/9252a04eae9bc0da12c96b7e86b1000e7952c6e4