### PR TITLE
linux_resource/kernel_compat: replace obsolete egrep with grep -E

### DIFF
--- a/src/driver/linux_resource/kernel_compat.sh
+++ b/src/driver/linux_resource/kernel_compat.sh
@@ -165,7 +165,7 @@ EFRM_HUGETLB_FILE_SETUP_UCOUNTS	symtype	hugetlb_file_setup	include/linux/hugetlb
 EFRM_HUGETLB_FILE_SETUP_USER	symtype	hugetlb_file_setup	include/linux/hugetlb.h	struct file *(const char *, size_t, vm_flags_t, struct user_struct**, int, int)
 
 # TODO move onload-related stuff from net kernel_compat
-" | egrep -v -e '^#' -e '^$' | sed 's/[ \t][ \t]*/:/g'
+" | grep -E -v -e '^#' -e '^$' | sed 's/[ \t][ \t]*/:/g'
 }
 
 ######################################################################

--- a/src/driver/linux_resource/kernel_compat_funcs.sh
+++ b/src/driver/linux_resource/kernel_compat_funcs.sh
@@ -218,7 +218,7 @@ function test_symbol()
             fi
             [ -f "$KBUILD_SRC/$prefix$file" ] &&  \
                 strip_comments $KBUILD_SRC/$prefix$file | \
-                egrep -w "$symbol" >/dev/null && \
+                grep -E -w "$symbol" >/dev/null && \
                 return 0
         done
     done
@@ -304,13 +304,13 @@ function test_inline_symbol()
     # look for the inline..symbol. This is complicated since the inline
     # and the symbol may be on different lines.
     strip_comments $KBUILD_SRC/$file | \
-	egrep -m 1 -B 1 '(^|[,\* \(])'"$symbol"'($|[,; \(\)])' > $t
+	grep -E -m 1 -B 1 '(^|[,\* \(])'"$symbol"'($|[,; \(\)])' > $t
     [ $? = 0 ] || return $?
 
     # there is either an inline on the final line, or an inline and
     # no semicolon on the previous line
-    head -1 $t | egrep -q 'inline[^;]*$' && return
-    tail -1 $t | egrep -q 'inline' && return
+    head -1 $t | grep -E -q 'inline[^;]*$' && return
+    tail -1 $t | grep -E -q 'inline' && return
 
     return 1
 }
@@ -340,14 +340,14 @@ function test_export()
 		echo >&2 "Looking for export of $symbol in $KBUILD_SRC/$file"
             fi
             if [ -f $KBUILD_SRC/$file ]; then
-		egrep -q 'EXPORT_(PER_CPU)?SYMBOL(_GPL)?\('"$symbol"'\)' $KBUILD_SRC/$file && return
+		grep -E -q 'EXPORT_(PER_CPU)?SYMBOL(_GPL)?\('"$symbol"'\)' $KBUILD_SRC/$file && return
             fi
 	done
 	if [ -n "$MAP" ]; then
             if [ $efx_verbose = true ]; then
 		echo >&2 "Looking for export of $symbol in $MAP"
             fi
-	    egrep -q "[A-Z] $symbol\$" $MAP && return
+	    grep -E -q "[A-Z] $symbol\$" $MAP && return
 	fi
 	return 1
     fi
@@ -599,7 +599,7 @@ fi
 
 # filter the available symbols
 if [ -n "$FILTER" ]; then
-    kompat_symbols="$(echo "$kompat_symbols" | egrep "^($FILTER):")"
+    kompat_symbols="$(echo "$kompat_symbols" | grep -E "^($FILTER):")"
 fi
 
 compile_dir="$(mktemp -d)"


### PR DESCRIPTION
grep 3.8 prints warning about egrep obsolescence. As a result a lot of warnings appear when building Onload modules.
The patch hides these warnings by replacing 'egrep' with 'grep -E'.

Fixes #151

---
Testing:
`make -C build/x86_64_linux-6.2.10-100.fc36.x86_64/ HAVE_SFC=0` does not produce warnings.
`autocompat.h` file is generated correctly.