### PR TITLE
onload_tcpdump: fix maybe-uninitialized warning

### DIFF
--- a/src/tools/ip/tcpdump_bin.c
+++ b/src/tools/ip/tcpdump_bin.c
@@ -200,7 +200,8 @@ static inline ci_uint8 dump_hwport_val_get(void) {
  * dump_hwports. */
 static void ifindex_to_intf_i(ci_netif *ni)
 {
-  cicp_hwport_mask_t hwports;
+  /* Explicit initialization is needed to appease gcc. */
+  cicp_hwport_mask_t hwports = 0;
   int rc;
 
   memset(dump_hwports, OO_INTF_I_DUMP_NONE, sizeof(dump_hwports));


### PR DESCRIPTION
Onload GNU build fails on Fedora 38 with GCC 13.1.1: tcpdump_bin.c:230:11: error: ‘hwports’ may be used uninitialized [-Werror=maybe-uninitialized]

The patch fixes that error by initializing the local variable to zero.