### PR TITLE
epoll1: release reference to epoll fd in epoll_wait routine

### DIFF
--- a/src/driver/linux_onload/epoll_device.c
+++ b/src/driver/linux_onload/epoll_device.c
@@ -1148,6 +1148,7 @@ static long oo_epoll_fop_unlocked_ioctl(struct file* filp,
 
     rc = oo_epoll1_spin_on(filp, other_filp, local_arg.timeout_us,
                                              local_arg.sleep_iter_us);
+    fput(other_filp);
 
     if( signal_pending(current) )
       rc = -EINTR;
@@ -1186,6 +1187,7 @@ static long oo_epoll_fop_unlocked_ioctl(struct file* filp,
 #endif
 
     rc = oo_epoll1_block_on(filp, other_filp, local_arg.timeout_us);
+    fput(other_filp);
 
     if( signal_pending(current) )
       rc = -EINTR;


### PR DESCRIPTION
OO_EPOLL1_IOC_BLOCK_ON ioctl handler takes reference to epoll descriptor with fget(), but does not release it, which causes kernel memory leak on Linux 6.1. So, call fput() right after using it.

Fixes #154