### PR TITLE
linux_resource/ef10: make defines more unique

### DIFF
--- a/src/lib/efhw/ef10.c
+++ b/src/lib/efhw/ef10.c
@@ -240,29 +240,29 @@ static int _ef10_nic_check_35388_workaround(struct efhw_nic *nic)
 }
 
 
-#define IP_LOCAL	(1 << MC_CMD_FILTER_OP_IN_MATCH_DST_IP_LBN |\
-			 1 << MC_CMD_FILTER_OP_IN_MATCH_DST_PORT_LBN |\
-			 1 << MC_CMD_FILTER_OP_IN_MATCH_ETHER_TYPE_LBN |\
-			 1 << MC_CMD_FILTER_OP_IN_MATCH_IP_PROTO_LBN)
-#define IP_FULL 	(1 << MC_CMD_FILTER_OP_IN_MATCH_DST_IP_LBN |\
-			 1 << MC_CMD_FILTER_OP_IN_MATCH_DST_PORT_LBN |\
-			 1 << MC_CMD_FILTER_OP_IN_MATCH_SRC_IP_LBN |\
-			 1 << MC_CMD_FILTER_OP_IN_MATCH_SRC_PORT_LBN |\
-			 1 << MC_CMD_FILTER_OP_IN_MATCH_ETHER_TYPE_LBN |\
-			 1 << MC_CMD_FILTER_OP_IN_MATCH_IP_PROTO_LBN)
-#define VLAN_IP_WILD	(1 << MC_CMD_FILTER_OP_IN_MATCH_DST_IP_LBN |\
-			 1 << MC_CMD_FILTER_OP_IN_MATCH_DST_PORT_LBN |\
-			 1 << MC_CMD_FILTER_OP_IN_MATCH_ETHER_TYPE_LBN |\
-			 1 << MC_CMD_FILTER_OP_IN_MATCH_OUTER_VLAN_LBN |\
-			 1 << MC_CMD_FILTER_OP_IN_MATCH_IP_PROTO_LBN)
-#define ETH_LOCAL	(1 << MC_CMD_FILTER_OP_IN_MATCH_DST_MAC_LBN)
-#define ETH_LOCAL_VLAN	(1 << MC_CMD_FILTER_OP_IN_MATCH_DST_MAC_LBN |\
-			 1 << MC_CMD_FILTER_OP_IN_MATCH_OUTER_VLAN_LBN)
-#define UCAST_MISMATCH	(1<<MC_CMD_FILTER_OP_IN_MATCH_UNKNOWN_UCAST_DST_LBN)
-#define MCAST_MISMATCH	(1<<MC_CMD_FILTER_OP_IN_MATCH_UNKNOWN_MCAST_DST_LBN)
-#define IP_PROTOCOL	(1 << MC_CMD_FILTER_OP_IN_MATCH_ETHER_TYPE_LBN |\
-			 1 << MC_CMD_FILTER_OP_IN_MATCH_IP_PROTO_LBN)
-#define ETHERTYPE	(1 << MC_CMD_FILTER_OP_IN_MATCH_ETHER_TYPE_LBN)
+#define MC_FILTER_IP_LOCAL	(1 << MC_CMD_FILTER_OP_IN_MATCH_DST_IP_LBN |\
+				 1 << MC_CMD_FILTER_OP_IN_MATCH_DST_PORT_LBN | \
+				 1 << MC_CMD_FILTER_OP_IN_MATCH_ETHER_TYPE_LBN | \
+				 1 << MC_CMD_FILTER_OP_IN_MATCH_IP_PROTO_LBN)
+#define MC_FILTER_IP_FULL 	(1 << MC_CMD_FILTER_OP_IN_MATCH_DST_IP_LBN |\
+				 1 << MC_CMD_FILTER_OP_IN_MATCH_DST_PORT_LBN | \
+				 1 << MC_CMD_FILTER_OP_IN_MATCH_SRC_IP_LBN | \
+				 1 << MC_CMD_FILTER_OP_IN_MATCH_SRC_PORT_LBN | \
+				 1 << MC_CMD_FILTER_OP_IN_MATCH_ETHER_TYPE_LBN | \
+				 1 << MC_CMD_FILTER_OP_IN_MATCH_IP_PROTO_LBN)
+#define MC_FILTER_VLAN_IP_WILD	(1 << MC_CMD_FILTER_OP_IN_MATCH_DST_IP_LBN |\
+				 1 << MC_CMD_FILTER_OP_IN_MATCH_DST_PORT_LBN | \
+				 1 << MC_CMD_FILTER_OP_IN_MATCH_ETHER_TYPE_LBN | \
+				 1 << MC_CMD_FILTER_OP_IN_MATCH_OUTER_VLAN_LBN | \
+				 1 << MC_CMD_FILTER_OP_IN_MATCH_IP_PROTO_LBN)
+#define MC_FILTER_ETH_LOCAL	(1 << MC_CMD_FILTER_OP_IN_MATCH_DST_MAC_LBN)
+#define MC_FILTER_ETH_LOCAL_VLAN (1 << MC_CMD_FILTER_OP_IN_MATCH_DST_MAC_LBN | \
+				  1 << MC_CMD_FILTER_OP_IN_MATCH_OUTER_VLAN_LBN)
+#define MC_FILTER_UCAST_MISMATCH (1<<MC_CMD_FILTER_OP_IN_MATCH_UNKNOWN_UCAST_DST_LBN)
+#define MC_FILTER_MCAST_MISMATCH (1<<MC_CMD_FILTER_OP_IN_MATCH_UNKNOWN_MCAST_DST_LBN)
+#define MC_FILTER_IP_PROTOCOL	(1 << MC_CMD_FILTER_OP_IN_MATCH_ETHER_TYPE_LBN |\
+				 1 << MC_CMD_FILTER_OP_IN_MATCH_IP_PROTO_LBN)
+#define MC_FILTER_ETHERTYPE	(1 << MC_CMD_FILTER_OP_IN_MATCH_ETHER_TYPE_LBN)
 
 
 static int
@@ -306,23 +306,23 @@ ef10_ef100_nic_check_supported_filters(struct efhw_nic *nic) {
 	/* We check types of filters that may be used by onload, or ef_vi
 	 * users.  This information will be exposed by the capabilities API.
 	 */
-	if( _ef10_ef100_nic_check_supported_filter(out, num_matches, IP_LOCAL) )
+	if( _ef10_ef100_nic_check_supported_filter(out, num_matches, MC_FILTER_IP_LOCAL) )
 		nic->flags |= NIC_FLAG_RX_FILTER_TYPE_IP_LOCAL;
-	if( _ef10_ef100_nic_check_supported_filter(out, num_matches, IP_FULL) )
+	if( _ef10_ef100_nic_check_supported_filter(out, num_matches, MC_FILTER_IP_FULL) )
 		nic->flags |= NIC_FLAG_RX_FILTER_TYPE_IP_FULL;
-	if( _ef10_ef100_nic_check_supported_filter(out, num_matches, VLAN_IP_WILD) )
+	if( _ef10_ef100_nic_check_supported_filter(out, num_matches, MC_FILTER_VLAN_IP_WILD) )
 		nic->flags |= NIC_FLAG_VLAN_FILTERS;
-	if( _ef10_ef100_nic_check_supported_filter(out, num_matches, ETH_LOCAL) )
+	if( _ef10_ef100_nic_check_supported_filter(out, num_matches, MC_FILTER_ETH_LOCAL) )
 		nic->flags |= NIC_FLAG_RX_FILTER_TYPE_ETH_LOCAL;
-	if( _ef10_ef100_nic_check_supported_filter(out, num_matches, ETH_LOCAL_VLAN) )
+	if( _ef10_ef100_nic_check_supported_filter(out, num_matches, MC_FILTER_ETH_LOCAL_VLAN) )
 		nic->flags |= NIC_FLAG_RX_FILTER_TYPE_ETH_LOCAL_VLAN;
-	if( _ef10_ef100_nic_check_supported_filter(out, num_matches, IP_PROTOCOL) )
+	if( _ef10_ef100_nic_check_supported_filter(out, num_matches, MC_FILTER_IP_PROTOCOL) )
 		nic->flags |= NIC_FLAG_RX_FILTER_IP4_PROTO;
-	if( _ef10_ef100_nic_check_supported_filter(out, num_matches, ETHERTYPE) )
+	if( _ef10_ef100_nic_check_supported_filter(out, num_matches, MC_FILTER_ETHERTYPE) )
 		nic->flags |= NIC_FLAG_RX_FILTER_ETHERTYPE;
-	if( _ef10_ef100_nic_check_supported_filter(out, num_matches, UCAST_MISMATCH) )
+	if( _ef10_ef100_nic_check_supported_filter(out, num_matches, MC_FILTER_UCAST_MISMATCH) )
 		nic->flags |= NIC_FLAG_RX_FILTER_TYPE_UCAST_MISMATCH;
-	if( _ef10_ef100_nic_check_supported_filter(out, num_matches, MCAST_MISMATCH) )
+	if( _ef10_ef100_nic_check_supported_filter(out, num_matches, MC_FILTER_MCAST_MISMATCH) )
 		nic->flags |= NIC_FLAG_RX_FILTER_TYPE_MCAST_MISMATCH;
 
 	/* All fw variants support IPv6 filters */


### PR DESCRIPTION
Add prefixes to the filter defines to avoid potential clashes with kernel headers names and errors like this:
error: "IP_PROTOCOL" redefined [-Werror]

---

Build passes on Ubuntu 23.04 with kernel `6.3.7-060307-generic`.
Unfixed build (without the patch):
```
/home/nikitins/work/v5/build/x86_64_linux-6.3.7-060307-generic/driver/linux_resource/ef10.c:263: error: "IP_PROTOCOL" redefined [-Werror]                                                                          
  263 | #define IP_PROTOCOL     (1 << MC_CMD_FILTER_OP_IN_MATCH_ETHER_TYPE_LBN |\                                                                                                                                  
      |                                                                                                                                                                                                            
In file included from ./include/linux/in.h:19,                                                                                                                                                                     
                 from ./include/uapi/linux/netfilter.h:7,                                                                                                                                                          
                 from ./include/linux/netfilter_defs.h:5,                                                                                                                                                          
                 from ./include/net/netns/netfilter.h:5,                                                                                                                                                           
                 from ./include/net/net_namespace.h:25,                                                                                                                                                            
                 from ./include/linux/netdevice.h:38,                                                                                                                                                              
                 from /home/nikitins/work/v5/src/include/ci/efhw/sysdep_linux.h:51,                                                                                                                                
                 from /home/nikitins/work/v5/src/include/ci/efhw/sysdep.h:49,                                                                                                                                      
                 from /home/nikitins/work/v5/src/include/ci/efhw/common_sysdep.h:47,                                                                                                                               
                 from /home/nikitins/work/v5/src/include/ci/efhw/common.h:44,                                                                                                                                      
                 from /home/nikitins/work/v5/src/include/ci/driver/efab/hardware.h:54,                                                                                                                             
                 from /home/nikitins/work/v5/build/x86_64_linux-6.3.7-060307-generic/driver/linux_resource/ef10.c:34:                                                                                              
./include/uapi/linux/in.h:166: note: this is the location of the previous definition                                                                                                                               
  166 | #define IP_PROTOCOL                     52                                                                                                                                                                 
      |                                          
```