### PR TITLE
Handle XDP rings for linux>=6.3

### DIFF
--- a/src/include/ci/driver/kernel_compat.h
+++ b/src/include/ci/driver/kernel_compat.h
@@ -170,6 +170,14 @@ static inline void unpin_user_page(struct page *page)
 {
   put_page(page);
 }
+
+static inline void unpin_user_pages(struct page **pages, unsigned long npages)
+{
+  int i;
+
+  for( i = 0; i < npages; i++ )
+    put_page(pages[i]);
+}
 #endif
 
 #ifndef EFRM_GUP_HAS_DMA_PINNED


### PR DESCRIPTION
AF_XDP rings were allocated as physically-continuous memory before linux-6.3. Now rings are vmalloc'ed.  Let's map these new rings via pin_user_pages().

**Testing:**
Socket Tester sanity tests do not show any regression when using AF_XDP Onload with Debian Testing, kernels `6.3.0-0-amd64` and `6.1.0-9-amd64`