### PR TITLE
syscall_x86: Allow non-RAX indirect jumps

### DIFF
--- a/src/driver/linux_resource/syscall_x86.c
+++ b/src/driver/linux_resource/syscall_x86.c
@@ -48,16 +48,22 @@ static bool is_movq_indirect_8(const unsigned char *p)
  * or
  *  0f ae e8  lfence
  *  ff d0     callq *%rax     (linux-5.16 amd, see patch_retpoline())
+ * or
+ *  41 ff d3  callq *%r11     (linux-5.15 clang)
+ *  66 90     nop2
  */
 static bool is_callq_indirect_reg(const unsigned char *p)
 {
   if( p[0] == 0xe8 )
     return true;
-  if( p[0] == 0xff && p[1] == 0xd0 && p[2] == 0x0f && p[3] == 0x1f &&
+  if( p[0] == 0xff && (p[1] & 0xf8) == 0xd0 && p[2] == 0x0f && p[3] == 0x1f &&
       p[4] == 0x00 )
     return true;
   if( p[0] == 0x0f && p[1] == 0xae && p[2] == 0xe8 && p[3] == 0xff &&
-      p[4] == 0xd0 )
+      (p[1] & 0xf8) == 0xd0 )
+    return true;
+  if( p[0] == 0x41 && p[1] == 0xff && (p[2] & 0xf8) == 0xd0 && p[3] == 0x66 &&
+      p[4] == 0x90 )
     return true;
   return false;
 }


### PR DESCRIPTION
In a clang-compiled Linux we are testing with, the syscall retpoline jump was compiled to:

```
4c 8b 1c cd 90 02 20 82     mov    -0x7ddffd70(,%rcx,8),%r11
4c 89 f7                    mov    %r14,%rdi
e8 ad 5d 3b 00              call   <x86_indirect_thunk_r11>
```

Because R11 is an x86_64 extension register, emit_indirect() gives the modified call instruction an REX.B prefix (0x41), becoming:

```
41 ff d3                    call   *%r11
66 90                       nop2
```

This patch adds a condition for such. It also allows other non-extension-registers that isn't RAX to be used, instead of hardcoding 0xd0 for RAX.

I believe in the case of X86_FEATURE_RETPOLINE_LFENCE with extension registers, the patch simply won't be performed, because lfence + call now takes 6 bytes and apply_retpolines skips the patch when the length does not match. I have not tested this yet however.