### PR TITLE
Fix build on Linux 6.4

### DIFF
--- a/src/driver/linux_resource/kernel_compat.sh
+++ b/src/driver/linux_resource/kernel_compat.sh
@@ -164,6 +164,8 @@ EFRM_HUGETLB_FILE_SETUP		symtype	hugetlb_file_setup	include/linux/hugetlb.h	stru
 EFRM_HUGETLB_FILE_SETUP_UCOUNTS	symtype	hugetlb_file_setup	include/linux/hugetlb.h	struct file *(const char *, size_t, vm_flags_t, struct ucounts **, int, int)
 EFRM_HUGETLB_FILE_SETUP_USER	symtype	hugetlb_file_setup	include/linux/hugetlb.h	struct file *(const char *, size_t, vm_flags_t, struct user_struct**, int, int)
 
+EFRM_CLASS_CREATE_NO_MODULE symtype class_create include/linux/device/class.h struct class *(const char *)
+
 # TODO move onload-related stuff from net kernel_compat
 " | grep -E -v -e '^#' -e '^$' | sed 's/[ \t][ \t]*/:/g'
 }

--- a/src/driver/linux_resource/kernel_compat.sh
+++ b/src/driver/linux_resource/kernel_compat.sh
@@ -166,6 +166,8 @@ EFRM_HUGETLB_FILE_SETUP_USER	symtype	hugetlb_file_setup	include/linux/hugetlb.h	
 
 EFRM_CLASS_CREATE_NO_MODULE symtype class_create include/linux/device/class.h struct class *(const char *)
 
+EFRM_HAVE_ITER_IOV symbol iter_iov include/linux/uio.h
+
 # TODO move onload-related stuff from net kernel_compat
 " | grep -E -v -e '^#' -e '^$' | sed 's/[ \t][ \t]*/:/g'
 }

--- a/src/include/ci/driver/chrdev.h
+++ b/src/include/ci/driver/chrdev.h
@@ -5,7 +5,7 @@
 #include <linux/fs.h>
 #include <linux/device.h>
 #include <linux/cdev.h>
-#include "driver/linux_resource/autocompat.h"
+#include "ci/driver/kernel_compat.h"
 
 /* This file contains some simple utility functions for creating char
  * devices and their corresponding nodes in /dev, which are needed by most of
@@ -85,7 +85,7 @@ ci_inline int create_chrdev_and_mknod(int major, int minor, const char* name,
     goto fail_free;
   }
 
-  reg->class = class_create(THIS_MODULE, name);
+  reg->class = ci_class_create(name);
   if( IS_ERR(reg->class) ) {
     rc = PTR_ERR(reg->class);
     reg->class = NULL;

--- a/src/include/ci/driver/kernel_compat.h
+++ b/src/include/ci/driver/kernel_compat.h
@@ -441,4 +441,17 @@ static inline u32 get_random_u32(void)
 }
 #endif
 
+#ifdef EFRM_CLASS_CREATE_NO_MODULE
+/* linux >= 6.4 */
+/* NOTE: there are revisions between linux-6.3 and linux-6.4 where
+ *       'class_create' is defined as follows:
+ *       #define class_create(name)
+ *       Such definition is not handled by this compat code, so build is broken
+ *       on those revisions. It does not involve any release Linux versions, but
+ *       you may face build problems when bisecting Linux. */
+#define ci_class_create(__name) class_create(__name)
+#else
+#define ci_class_create(__name) class_create(THIS_MODULE, __name)
+#endif
+
 #endif /* DRIVER_LINUX_RESOURCE_KERNEL_COMPAT_H */

--- a/src/lib/efthrm/tcp_helper_linux.c
+++ b/src/lib/efthrm/tcp_helper_linux.c
@@ -31,6 +31,11 @@
 #ifdef EFRM_HAVE_FOP_READ_ITER
 /* linux >= 3.16 */
 
+#ifndef EFRM_HAVE_ITER_IOV
+/* linux < 6.4 */
+#define iter_iov(iter) (iter)->iov
+#endif
+
 #ifdef EFRM_HAVE_ITER_UBUF
 /* linux >= 6.0
  * See kernel commits
@@ -46,7 +51,7 @@
       struct iovec iov = { .iov_base = v->ubuf, .iov_len = v->count };  \
       return base_handler(iocb->ki_filp, &iov, 1);                      \
     }                                                                   \
-    return base_handler(iocb->ki_filp, v->iov, v->nr_segs);             \
+    return base_handler(iocb->ki_filp, iter_iov(v), v->nr_segs);        \
   } while (0);
 
 #else
@@ -55,7 +60,7 @@
 
 #define FOP_RW_ITER_CALL_BASE_HANDLER(base_handler, iocb, iter)         \
   do {                                                                  \
-    return base_handler(iocb->ki_filp, v->iov, v->nr_segs);             \
+    return base_handler(iocb->ki_filp, iter_iov(v), v->nr_segs);        \
   } while (0);
 
 #endif /* EFRM_HAVE_ITER_UBUF */


### PR DESCRIPTION
This PR fixes modules build errors on Linux 6.4:
```
onload/src/include/ci/driver/chrdev.h: In function ‘create_chrdev_and_mknod’:
/usr/src/linux-headers-6.4.0-0-common/include/linux/export.h:27:22: error: passing argument 1 of ‘class_create’ from incompatible pointer type [-Werror=incompatible-pointer-types]
   27 | #define THIS_MODULE (&__this_module)
      |                     ~^~~~~~~~~~~~~~~
      |                      |
      |                      struct module *
onload/src/include/ci/driver/chrdev.h:88:29: note: in expansion of macro ‘THIS_MODULE’
   88 |   reg->class = class_create(THIS_MODULE, name);
      |                             ^~~~~~~~~~~
```
and
```
build/x86_64_linux-6.4.0-0-amd64/driver/linux_onload/tcp_helper_linux.c:49:43: error: ‘struct iov_iter’ has no member named ‘iov’; did you mean ‘__iov’?                                    
   49 |     return base_handler(iocb->ki_filp, v->iov, v->nr_segs);             \                                                                                                                                  
      |                                           ^~~        
```
---
Checked by building on kernels:
6.4.0-0-amd64
6.3.0-1-amd64
5.15.0-72-generic