### PR TITLE
linux_resource/kernel_compat_funcs: Fix hang when $KBUILD_MODULE_SYMVERS is empty

### DIFF
--- a/src/driver/linux_resource/kernel_compat_funcs.sh
+++ b/src/driver/linux_resource/kernel_compat_funcs.sh
@@ -329,7 +329,7 @@ function test_export()
     #        May give a false positive if the export is conditional.
     #     3. The MAP file if present. May give a false positive
     #        because it lists all extern (not only exported) symbols.
-    if [ -f $KBUILD_MODULE_SYMVERS ]; then
+    if [[ $KBUILD_MODULE_SYMVERS && -f $KBUILD_MODULE_SYMVERS ]]; then
         if [ $efx_verbose = true ]; then
             echo >&2 "Looking for export of $symbol in $KBUILD_MODULE_SYMVERS"
 	fi

--- a/src/driver/linux_resource/kernel_compat_funcs.sh
+++ b/src/driver/linux_resource/kernel_compat_funcs.sh
@@ -329,7 +329,7 @@ function test_export()
     #        May give a false positive if the export is conditional.
     #     3. The MAP file if present. May give a false positive
     #        because it lists all extern (not only exported) symbols.
-    if [[ $KBUILD_MODULE_SYMVERS && -f $KBUILD_MODULE_SYMVERS ]]; then
+    if [ -f "$KBUILD_MODULE_SYMVERS" ]; then
         if [ $efx_verbose = true ]; then
             echo >&2 "Looking for export of $symbol in $KBUILD_MODULE_SYMVERS"
 	fi


### PR DESCRIPTION
kernel_compat_funcs performs an awk on $KBUILD_MODULE_SYMVERS even when it is empty. This causes the script to hang forever. Add a check for if $KBUILD_MODULE_SYMVERS is empty before the awk.