### PR TITLE
AF_XDP support for rx timestamps

### DIFF
--- a/src/lib/efhw/af_xdp.c
+++ b/src/lib/efhw/af_xdp.c
@@ -20,6 +20,7 @@
 #include <linux/fdtable.h>
 #include <linux/sched/signal.h>
 #include <net/sock.h>
+#include <net/xdp.h>
 
 #include <ci/efrm/syscall.h>
 #include <ci/efrm/efrm_filter.h>
@@ -1084,6 +1085,10 @@ has_map_and_bound_prog:
 	memcpy(nic->mac_addr, mac_addr, ETH_ALEN);
 
 	af_xdp_nic_tweak_hardware(nic);
+
+	if (nic->net_dev->xdp_metadata_ops &&
+	    nic->net_dev->xdp_metadata_ops->xmo_rx_timestamp)
+		nic->flags |= NIC_FLAG_HW_RX_TIMESTAMPING;
 
 	rc = af_xdp_rss_get_support(nic);
 	return rc;

--- a/src/lib/transport/ip/netif_event.c
+++ b/src/lib/transport/ip/netif_event.c
@@ -207,6 +207,24 @@ static void get_rx_timestamp(ci_netif* netif, ci_ip_pkt_fmt* pkt)
   ci_netif_state_nic_t* nsn = &netif->state->nic[pkt->intf_i];
   ef_vi* vi = ci_netif_vi(netif, pkt->intf_i);
 
+  /* AF_XDP timestamps are read in ci_netif_poll_evq
+   * TODO: probably move here. we have all necessary data: vi and pkt */
+  if( vi->nic_type.arch == EF_VI_ARCH_AF_XDP ) {
+    struct onload_xdp_rx_meta {
+#define ONLOAD_XDP_RX_META_TSTAMP 0x1
+      uint64_t flags;
+      uint64_t tstamp;
+    } *meta;
+    const uint64_t ns_to_sec = 1000UL * 1000 * 1000;
+
+    meta = ((struct onload_xdp_rx_meta *)(pkt->dma_start + pkt->pkt_start_off)) - 1;
+    if (meta->flags & ONLOAD_XDP_RX_META_TSTAMP) {
+      pkt->hw_stamp.tv_sec = meta->tstamp / ns_to_sec;
+      pkt->hw_stamp.tv_nsec = meta->tstamp % ns_to_sec;
+    }
+    return;
+  }
+
   if( (vi->nic_type.arch != EF_VI_ARCH_EFCT) &&
       (nsn->oo_vi_flags & OO_VI_FLAGS_RX_HW_TS_EN) ) {
     unsigned sync_flags;

--- a/src/tools/bpf_link_helper/xdp_onload_prepare.c
+++ b/src/tools/bpf_link_helper/xdp_onload_prepare.c
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: GPL-2.0
+
+/* xdp_onload_prepare -- load an XDP ELF object with xsk map and program
+ *
+ * cd $SOMEDIR
+ * git clone --recurse-submodules https://github.com/libbpf/bpftool.git
+ * cd bpftool
+ * export BPFTOOL=$PWD
+ * make
+ *
+ * cd $ONLOAD
+ * cd src/tools/bpf_link_helper
+ * gcc -Wall -o xdp_onload_prepare xdp_onload_prepare.c -L $BPFTOOL/libbpf/src -lbpf -I $BPFTOOL/libbpf/src/
+ */
+
+#include <errno.h>
+#include <error.h>
+#include <linux/if_link.h>
+#include <net/if.h>
+#include <stdlib.h>
+
+#include "libbpf.h"
+#include "bpf.h"
+
+int main(int argc, char **argv)
+{
+	struct bpf_object *obj;
+	struct bpf_program *prog;
+	struct bpf_map *map_xsk;
+	int prog_fd, ifindex;
+
+	if (argc != 3)
+		error(1, 0, "Usage: %s [ifname] [bpf_file]\n", argv[0]);
+
+	ifindex = if_nametoindex(argv[1]);
+	if (!ifindex)
+		error(1, errno, "if_nametoindex %s", argv[1]);
+
+	obj = bpf_object__open(argv[2]);
+	if (!obj)
+		error(1, errno, "bpf_object_open %s", argv[2]);
+
+	map_xsk = bpf_object__find_map_by_name(obj, "onload_xdp_xsk");
+	if (!map_xsk)
+		error(1, 0, "bpf_object__find_map_by_name onload_xdp_xsk");
+
+	prog = bpf_object__find_program_by_name(obj, "xdp_onload_prog");
+	if (!prog)
+		error(1, 0, "bpf_object__find_program_by_name");
+
+	bpf_program__set_ifindex(prog, ifindex);
+	bpf_program__set_flags(prog, BPF_F_XDP_DEV_BOUND_ONLY);
+
+	if (bpf_object__load(obj) < 0)
+		error(1, errno, "bpf_object__load");
+
+	prog_fd = bpf_program__fd(prog);
+	if (prog_fd < 0)
+		error(1, 0, "bpf_program__fd");
+
+	if (bpf_xdp_attach(ifindex, prog_fd, XDP_FLAGS_DRV_MODE, NULL))
+		error(1, 0, "bpf_program__attach_xdp");
+
+	if (bpf_object__pin_maps(obj, "/sys/fs/bpf"))
+		error(1, 0, "bpf_object__pin_maps");
+
+	printf("OK\n");
+	return 0;
+}

--- a/src/tools/bpf_link_helper/xdp_tstamp.c
+++ b/src/tools/bpf_link_helper/xdp_tstamp.c
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: GPL-2.0
+
+/* xdp_tstamp.c -- xdp program that reads optional hw rx timestamp
+ *
+ * See also https://docs.kernel.org/networking/xdp-rx-metadata.html
+ *
+ *
+ * # BUILD
+ *
+ * # install bpftool (if not installed yet)
+ * cd $SOMEDIR
+ * git clone --recurse-submodules https://github.com/libbpf/bpftool.git
+ * cd bpftool
+ * export BPFTOOL=$PWD
+ * make
+ *
+ * # install xdp-tools
+ * cd $SOMEDIR
+ * git clone https://github.com/xdp-project/xdp-tools.git
+ * cd xdp-tools
+ * XDPTOOLS=$PWD
+ * ./configure
+ * make
+ *
+ * cd $ONLOAD
+ * cd src/tools/bpf_link_helper
+ * clang -g -target bpf -O2 -I $BPFTOOL/src/libbpf/include -I XDPTOOLS/headers -c xdp_tstamp.c -o ./xdp_tstamp.o
+ *
+ *
+ * # RUN
+ *
+ * # insert the xdp prog *before* loading the onload kernel modules
+ * ./xdp_onload_prepare $DEV xdp_tstamp.o
+ */
+
+#include <linux/bpf.h>
+#include <bpf/bpf_helpers.h>
+#include <xdp/xdp_helpers.h>
+
+/* must match map created by onload/src/lib/efhw/af_xdp.c
+ *
+ * max_entries matches the number passed to
+ * /sys/module/sfc_resource/afxdp/register
+ */
+struct {
+	__uint(type, BPF_MAP_TYPE_XSKMAP);
+	__uint(key_size, sizeof(int));
+	__uint(value_size, sizeof(int));
+	__uint(max_entries, 4);
+} onload_xdp_xsk SEC(".maps");
+
+struct onload_xdp_rx_meta {
+#define ONLOAD_XDP_RX_META_TSTAMP 0x1
+	__u64 flags;
+	__u64 tstamp;
+};
+
+extern int bpf_xdp_metadata_rx_timestamp(const struct xdp_md *ctx,
+					 __u64 *timestamp) __ksym;
+
+SEC("xdp")
+int xdp_onload_prog(struct xdp_md *ctx)
+{
+	struct onload_xdp_rx_meta *meta;
+	void *data, *data_meta;
+	int ret;
+
+	ret = bpf_xdp_adjust_meta(ctx, -(int)(sizeof(struct onload_xdp_rx_meta)));
+	if (ret != 0)
+		return XDP_PASS;
+
+	data = (void *)(long)ctx->data;
+	data_meta = (void *)(long)ctx->data_meta;
+
+	if ((data_meta + sizeof(*meta)) > data)
+		return XDP_PASS;
+
+	meta = data_meta;
+
+	meta->tstamp = 0;
+	if (!bpf_xdp_metadata_rx_timestamp(ctx, &meta->tstamp))
+		meta->flags = ONLOAD_XDP_RX_META_TSTAMP;
+	else
+		meta->flags = 0;
+
+	return bpf_redirect_map(&onload_xdp_xsk, ctx->rx_queue_index, XDP_PASS);
+}
+
+char _license[] SEC("license") = "GPL";


### PR DESCRIPTION
This is an initial demonstrator of how to support hardware receive timestamps in the af_xdp ef_vi.

Create a new XDP program that uses the recently added XDP rx metadata to (1) read the hardware timestamp if supported by the device and (2) store this in the AF_XDP buffer in headroom before the packet.

Update Onload to read this headroom and convert to the internal pkt timestamp fields.

To make this possible, also (1) add support for using externally compiled XDP programs and (2) add an optional map that advertises optional features of the XDP program.