### PR TITLE
Fix build for Linux 6.5

### DIFF
--- a/src/driver/linux_char/efch_memreg.c
+++ b/src/driver/linux_char/efch_memreg.c
@@ -232,9 +232,9 @@ memreg_rm_alloc(ci_resource_alloc_t* alloc_,
 
   mmap_read_lock(current->mm);
   for (mr->n_pages = 0; mr->n_pages < max_pages; mr->n_pages += rc) {
-    rc = pin_user_pages(first_page + mr->n_pages * PAGE_SIZE,
-                        max_pages - mr->n_pages, FOLL_WRITE,
-                        mr->pages + mr->n_pages, NULL);
+    rc = ci_pin_user_pages(first_page + mr->n_pages * PAGE_SIZE,
+                           max_pages - mr->n_pages, FOLL_WRITE,
+                           mr->pages + mr->n_pages);
     if (rc <= 0) {
       EFCH_ERR("%s: ERROR: pin_user_pages(%d) returned %d",
                __FUNCTION__, max_pages - mr->n_pages, rc);

--- a/src/driver/linux_onload/dshm.c
+++ b/src/driver/linux_onload/dshm.c
@@ -112,9 +112,9 @@ oo_dshm_register_impl(ci_int32 shm_class, ci_user_ptr_t user_addr,
 
   /* Take references to the pages from the user's buffer. */
   mmap_read_lock(current->mm);
-  rc = pin_user_pages((unsigned long) CI_USER_PTR_GET(user_addr),
-                      buffer->num_pages, 0 /* read-only, no force */,
-                      buffer->pages, NULL);
+  rc = ci_pin_user_pages((unsigned long) CI_USER_PTR_GET(user_addr),
+                         buffer->num_pages, 0 /* read-only, no force */,
+                         buffer->pages);
   mmap_read_unlock(current->mm);
 
   if( rc < (int)buffer->num_pages ) {

--- a/src/driver/linux_onload/tcp_sendpage.c
+++ b/src/driver/linux_onload/tcp_sendpage.c
@@ -18,6 +18,7 @@
 #if ! CI_CFG_UL_INTERRUPT_HELPER
 CI_BUILD_ASSERT(CI_SB_AFLAG_O_NONBLOCK == MSG_DONTWAIT);
 
+#ifdef EFRM_HAVE_FOP_SENDPAGE
 
 ci_inline int sendpage_copy(ci_netif* ni, ci_tcp_state* ts, struct page* page,
                             int offset, size_t size, int flags)
@@ -91,4 +92,5 @@ ssize_t linux_tcp_helper_fop_sendpage_udp(struct file* filp,
                    page, offset, size, ppos, flags);
   return rc;
 }
+#endif /* EFRM_HAVE_FOP_SENDPAGE */
 #endif

--- a/src/driver/linux_resource/kernel_compat.sh
+++ b/src/driver/linux_resource/kernel_compat.sh
@@ -27,6 +27,7 @@ EFRM_SOCK_SENDMSG_NEEDS_LEN	symtype	sock_sendmsg	include/linux/net.h int(struct 
 EFRM_SOCK_RECVMSG_NEEDS_BYTES	symtype sock_recvmsg	include/linux/net.h int(struct socket *, struct msghdr *, size_t, int)
 
 EFRM_HAVE_FOP_READ_ITER	memtype	struct_file_operations	read_iter	include/linux/fs.h ssize_t (*) (struct kiocb *, struct iov_iter *)
+EFRM_HAVE_FOP_SENDPAGE		memtype	struct_file_operations	sendpage	include/linux/fs.h ssize_t (*) (struct file *, struct page *, int, size_t, loff_t *, int)
 
 EFRM_SOCK_CREATE_KERN_HAS_NET	symtype	sock_create_kern	include/linux/net.h int(struct net *, int, int, int, struct socket **)
 

--- a/src/driver/linux_resource/kernel_compat.sh
+++ b/src/driver/linux_resource/kernel_compat.sh
@@ -66,6 +66,7 @@ EFRM_GUP_RCLONG_TASK_SEPARATEFLAGS symtype get_user_pages include/linux/mm.h lon
 EFRM_GUP_RCLONG_TASK_COMBINEDFLAGS symtype get_user_pages include/linux/mm.h long(struct task_struct *, struct mm_struct *, unsigned long, unsigned long, unsigned int, struct page **, struct vm_area_struct **)
 EFRM_GUP_RCLONG_NOTASK_COMBINEDFLAGS symtype get_user_pages include/linux/mm.h long(unsigned long, unsigned long, unsigned int, struct page **, struct vm_area_struct **)
 EFRM_GUP_HAS_PIN	symbol	pin_user_pages	include/linux/mm.h
+EFRM_GUP_PIN_HAS_VMAS	symtype	pin_user_pages	include/linux/mm.h	long(unsigned long, unsigned long, unsigned int, struct page **, struct vm_area_struct **)
 EFRM_GUP_HAS_DMA_PINNED	symbol	page_maybe_dma_pinned	include/linux/mm.h
 
 EFRM_HAVE_USERMODEHELPER_SETUP		symbol	call_usermodehelper_setup	include/linux/kmod.h

--- a/src/include/ci/driver/kernel_compat.h
+++ b/src/include/ci/driver/kernel_compat.h
@@ -104,9 +104,8 @@
 /* linux-5.6 have got pin_user_pages() */
 #ifndef EFRM_GUP_HAS_PIN
 static inline long
-pin_user_pages(unsigned long start, unsigned long nr_pages,
-	       unsigned int gup_flags, struct page **pages,
-	       struct vm_area_struct **vmas)
+ci_pin_user_pages(unsigned long start, unsigned long nr_pages,
+		  unsigned int gup_flags, struct page **pages)
 {
   /* We support four get_user_pages() function prototypes here,
    * including an intermediate one that has one of the changes but not
@@ -163,7 +162,7 @@ pin_user_pages(unsigned long start, unsigned long nr_pages,
                                          gup_flags & FOLL_WRITE, 
                                          gup_flags & FOLL_FORCE,
 #endif
-                                         pages, vmas);
+                                         pages, NULL);
 }
 
 static inline void unpin_user_page(struct page *page)
@@ -178,6 +177,16 @@ static inline void unpin_user_pages(struct page **pages, unsigned long npages)
   for( i = 0; i < npages; i++ )
     put_page(pages[i]);
 }
+#else /* EFRM_GUP_HAS_PIN */
+
+/* linux-6.5 removes vmas parameter from pin_user_pages() */
+#ifndef EFRM_GUP_PIN_HAS_VMAS
+#define ci_pin_user_pages pin_user_pages
+#else
+#define ci_pin_user_pages(start, nr_pages, gup_flags, pages) \
+  pin_user_pages((start), (nr_pages), (gup_flags), (pages), NULL)
+#endif
+
 #endif
 
 #ifndef EFRM_GUP_HAS_DMA_PINNED

--- a/src/lib/efhw/af_xdp.c
+++ b/src/lib/efhw/af_xdp.c
@@ -97,7 +97,7 @@ static int __sys_call_area_alloc(struct sys_call_area* area, const char* func)
   }
 
   mmap_read_lock(current->mm);
-  rc = pin_user_pages(area->user_addr, 1, FOLL_WRITE, &area->page, NULL);
+  rc = ci_pin_user_pages(area->user_addr, 1, FOLL_WRITE, &area->page);
   mmap_read_unlock(current->mm);
   if( rc != 1 ) {
     EFHW_ERR("%s: ERROR: failed to get a page: rc=%d:", func, rc);
@@ -621,7 +621,7 @@ static int xdp_create_ring(struct socket* sock,
     }
     else {
       mmap_read_lock(current->mm);
-      rc = pin_user_pages(addr, pages, FOLL_WRITE, ring_mapping->pages, NULL);
+      rc = ci_pin_user_pages(addr, pages, FOLL_WRITE, ring_mapping->pages);
       mmap_read_unlock(current->mm);
 
       if( rc == pages )

--- a/src/lib/efthrm/tcp_helper_resource.c
+++ b/src/lib/efthrm/tcp_helper_resource.c
@@ -6412,8 +6412,8 @@ static long efab_get_all_user_pages(unsigned long base, long max_pages,
 
   mmap_read_lock(current->mm);
   for( n = 0; n < max_pages; n += rc ) {
-    rc = pin_user_pages(base + n * PAGE_SIZE, max_pages - n, gup_flags,
-                        pages + n, NULL);
+    rc = ci_pin_user_pages(base + n * PAGE_SIZE, max_pages - n, gup_flags,
+                           pages + n);
     if (rc <= 0) {
       efab_put_pages(pages, n);
       mmap_read_unlock(current->mm);

--- a/src/lib/kernel_utils/hugetlb.c
+++ b/src/lib/kernel_utils/hugetlb.c
@@ -192,7 +192,7 @@ oo_hugetlb_page_alloc_raw(struct oo_hugetlb_allocator *allocator,
 	}
 
 	mmap_read_lock(current->mm);
-	rc = pin_user_pages(addr, 1, FOLL_WRITE, page_out, NULL);
+	rc = ci_pin_user_pages(addr, 1, FOLL_WRITE, page_out);
 	mmap_read_unlock(current->mm);
 
 	vm_munmap(addr, OO_HUGEPAGE_SIZE);


### PR DESCRIPTION
linux-6.5: support updated pin_user_pages  
linux-6.5: compat for splice() and f_ops->sendpage

---
Build passes on Debian-testing (trixie) with 6.5 and 6.4 kernels.
Also checked with the related socket-tester tests:
```
--tester-run=sockapi-ts/ --ool=onload --tester-req=SENDFILE
--tester-run=sockapi-ts/usecases/splice:splice_before_data=FALSE,set_move=FALSE,set_nonblock=FALSE,extra_pipes=0,overfill_pipe=FALSE,acc_pipe=FALSE,di
ff_stacks=FALSE,check_after_splice=FALSE --ool=onload
```
No regressions.