### PR TITLE
driver/linux_onload: remove wrong sendpage assertion

### DIFF
--- a/src/driver/linux_onload/tcp_sendpage.c
+++ b/src/driver/linux_onload/tcp_sendpage.c
@@ -54,7 +54,6 @@ ssize_t linux_tcp_helper_fop_sendpage(struct file* filp, struct page* page,
   ci_assert(page);
   ci_assert_ge(offset, 0);
   ci_assert_gt(size, 0);
-  ci_assert_le(offset + size, CI_PAGE_SIZE);
 
 #ifndef MSG_SENDPAGE_NOTLAST
   /* "flags" is really "more".  Convert it. */


### PR DESCRIPTION
Onload used to assert that a memory chunk passed to sendpage handler is always within one page.  It was true at the time when the assertion was added.  It is not true any more.

If a user runs two splice() calls: OS socket -> OS pipe -> Onload socket, then Onload's sendpage handler gets a whole memory-continuous packet as it was received by the NIC.  Such a packet tend to be a part of a compound page, and it may cross the bounds of an ordinary page.

The real sense of this assertion was "ensure that we are handling a continuous chunk".  This is still true.  But the assertion is bad for linux>=6.1 and for some updates of older kernels.

Fixes #173 