### PR TITLE
Fix listen() backlog handling

### DIFF
--- a/src/include/ci/internal/ip.h
+++ b/src/include/ci/internal/ip.h
@@ -4694,6 +4694,16 @@ ci_inline void ci_tcp_acceptq_put_back(ci_netif* ni, ci_tcp_socket_listen* tls,
 }
 
 
+ci_inline void ci_tcp_acceptq_drop_stats_inc(ci_netif* ni,
+                                             ci_tcp_socket_listen* tls,
+                                             const char* lpf) {
+  CI_TCP_EXT_STATS_INC_LISTEN_OVERFLOWS(ni);
+  LOG_U(ci_log("%s" NT_FMT "accept queue is full (n=%d max=%d)",
+               lpf, NT_PRI_ARGS(ni, tls), ci_tcp_acceptq_n(tls),
+               tls->acceptq_max));
+  CITP_STATS_TCP_LISTEN(++tls->stats.n_acceptq_overflow);
+}
+
 /*********************************************************************
 ******************************** Netif *******************************
 *********************************************************************/

--- a/src/include/ci/internal/opts_netif_def.h
+++ b/src/include/ci/internal/opts_netif_def.h
@@ -882,6 +882,11 @@ CI_CFG_OPT("EF_ACCEPTQ_MIN_BACKLOG", acceptq_min_backlog, ci_uint16,
 "call.  If the application requests a smaller value, use this value instead.",
            , , 1, MIN, MAX, count)
 
+CI_CFG_OPT("EF_ACCEPTQ_MAX_BACKLOG", acceptq_max_backlog, ci_uint32,
+"Maximum value of 'backlog' argument in listen() call (accept queue maximum "
+"size). The value from /proc/sys/core/somaxconn is used by default.",
+           , , SOMAXCONN, MIN, MAX, count)
+
 CI_CFG_OPT("EF_NONAGLE_INFLIGHT_MAX", nonagle_inflight_max, ci_uint16,
 "This option affects the behaviour of TCP sockets with the TCP_NODELAY socket "
 "option.  Nagle's algorithm is enabled when the number of packets in-flight "

--- a/src/lib/transport/ip/netif_init.c
+++ b/src/lib/transport/ip/netif_init.c
@@ -279,6 +279,7 @@ static ci_uint32 citp_udp_sndbuf_def = CI_CFG_UDP_SNDBUF_DEFAULT;
 static ci_uint32 citp_udp_rcvbuf_max = CI_CFG_UDP_RCVBUF_MAX;
 static ci_uint32 citp_udp_rcvbuf_def = CI_CFG_UDP_RCVBUF_DEFAULT;
 static ci_uint32 citp_tcp_backlog_max = CI_TCP_LISTENQ_MAX;
+static ci_uint32 citp_somaxconn = SOMAXCONN;
 static ci_uint32 citp_tcp_adv_win_scale_max = CI_TCP_WSCL_MAX;
 static ci_uint32 citp_fin_timeout = CI_CFG_TCP_FIN_TIMEOUT;
 static ci_uint32 citp_retransmit_threshold = CI_TCP_RETRANSMIT_THRESHOLD;
@@ -385,6 +386,9 @@ ci_setup_ipstack_params(void)
     citp_udp_rcvbuf_max = opt[0];
   if( ci_sysctl_get_values("net/core/rmem_default", opt, 1) == 0 )
     citp_udp_rcvbuf_def = opt[0];
+
+  if( ci_sysctl_get_values("net/core/somaxconn", opt, 1) == 0 )
+    citp_somaxconn = opt[0];
 
   if (ci_sysctl_get_values("net/ipv4/tcp_max_syn_backlog", opt, 1) == 0)
     citp_tcp_backlog_max = opt[0];
@@ -530,6 +534,8 @@ void ci_netif_config_opts_defaults(ci_netif_config_opts* opts)
                                  citp_tcp_early_retransmit < 4;
     opts->tail_drop_probe = citp_tcp_early_retransmit >= 3;
     opts->oow_ack_ratelimit = citp_tcp_invalid_ratelimit;
+
+    opts->acceptq_max_backlog = citp_somaxconn;
 #if CI_CFG_IPV6
     opts->auto_flowlabels = citp_auto_flowlabels;
 #endif
@@ -1015,6 +1021,8 @@ void ci_netif_config_opts_getenv(ci_netif_config_opts* opts)
 
   if( (s = getenv("EF_ACCEPTQ_MIN_BACKLOG")) )
     opts->acceptq_min_backlog = atoi(s);
+  if( (s = getenv("EF_ACCEPTQ_MAX_BACKLOG")) )
+    opts->acceptq_max_backlog = atoi(s);
 
   if ( (s = getenv("EF_TCP_SNDBUF")) )
     opts->tcp_sndbuf_user = atoi(s);

--- a/src/lib/transport/ip/tcp_synrecv.c
+++ b/src/lib/transport/ip/tcp_synrecv.c
@@ -1001,11 +1001,7 @@ int ci_tcp_listenq_try_promote(ci_netif* netif, ci_tcp_socket_listen* tls,
     *ts_out = ts;
     return 0;
   }
-  CI_TCP_EXT_STATS_INC_LISTEN_OVERFLOWS( netif );
-  LOG_U(log(LPF LNT_FMT" accept queue is full (n=%d max=%d)",
-            LNT_PRI_ARGS(netif, tls), ci_tcp_acceptq_n(tls), tls->acceptq_max));
-  CITP_STATS_TCP_LISTEN(++tls->stats.n_acceptq_overflow);
-
+  ci_tcp_acceptq_drop_stats_inc(netif, tls, LPF);
   return -ENOSPC;
 }
 

--- a/src/lib/transport/unix/tcp_fd.c
+++ b/src/lib/transport/unix/tcp_fd.c
@@ -527,6 +527,9 @@ static int citp_tcp_listen(citp_fdinfo* fdinfo, int backlog)
   Log_VSS(ci_log(LPF "listen("EF_FMT", %d)", EF_PRI_ARGS(epi,fdinfo->fd),
               backlog));
 
+  if( (unsigned)backlog > NI_OPTS(epi->sock.netif).acceptq_max_backlog )
+    backlog = NI_OPTS(epi->sock.netif).acceptq_max_backlog;
+
   if( epi->sock.s->s_flags & (CI_SOCK_FLAGS_SCALABLE & ~CI_SOCK_FLAG_SCALPASSIVE) ) {
     /* We do not support IP_TRANSPARENT on listening sockets.  If this has
      * already been bound then we're past the point where we should have


### PR DESCRIPTION
### Initial issue
Linux and Onload handles the backlog argument of listen() function differently, starting from 4.10 (https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/commit/?id=5ea8ea2cb7f1d0db15762c9b0bb9e7330425a071).
When number of connection requests reaches the backlog:
Linux - drops SYN
Onload - responses with SYNACK, and only then drops ACK from peer.

### The fix
Two commits are proposed:
```
lib/transport: fix listen() backlog argument handling

Mimic Linux when accept queue is full - drop SYN.

See also Linux commit where the change was introduced:
5ea8ea2cb7f1d0db15762c9b0bb9e7330425a071

---

lib/transport: support somaxconn parameter

Use the /proc/sys/net/core/somaxconn value to limit accept queue
maximum size.
```

The first commit fixes the inconsistency and make Onload behave like Linux.
The second one adds support of `/proc/sys/net/core/somaxconn` parameter.

### Testing

Checked on a host with Ubuntu 22.04 (5.15.0-88-generic) by trivial tests:
- set `somaxconn=1`
- call `listen(backlog=1000)` and do not accept any connections

On peer: call connect() 2 times.
The second connect fail with `ETIMEDOUT` and the error appears in kernel logs `[onload] TCP RX 0:2047 accept queue is full (n=1 max=1)`

Also checked with Socket-tester tests:
```
--tester-run=sockapi-ts/tcp/listen_backlog_max \
--tester-run=sockapi-ts/usecases/multiple_listen \
--tester-run=sockapi-ts/basic/listen_backlog_values --ool=onload
```