### PR TITLE
driver: fix out-of-bounds UBSAN warning

### DIFF
--- a/src/driver/linux_onload/cplane.c
+++ b/src/driver/linux_onload/cplane.c
@@ -536,7 +536,7 @@ void cp_release(struct oo_cplane_handle* cp)
 
 struct cp_message {
   struct list_head link;
-  char buf[0];
+  __DECLARE_FLEX_ARRAY(char, buf);
 };
 
 struct cp_message_buffer {

--- a/src/include/ci/driver/chrdev.h
+++ b/src/include/ci/driver/chrdev.h
@@ -15,7 +15,7 @@ struct ci_chrdev_registration {
   dev_t devid;
   int count;
   struct class* class;
-  struct cdev* cdevs[0];
+  __DECLARE_FLEX_ARRAY(struct cdev*, cdevs);
 };
 
 struct ci_chrdev_node_params {

--- a/src/include/ci/driver/eftest_kernmem.h
+++ b/src/include/ci/driver/eftest_kernmem.h
@@ -57,7 +57,7 @@ struct eftest_kmcount_req {
 
 struct eftest_kmretrieve_req {
   int count_in_out; /* IN: expected OUT: actual */
-  struct eftest_kmem_req reqs_out[0];
+  __DECLARE_FLEX_ARRAY(struct eftest_kmem_req, reqs_out);
 } __attribute__((packed));
 
 #define EFTEST_KM_IOC_MAGIC     ('k')

--- a/src/include/ci/tools/sysdep.h
+++ b/src/include/ci/tools/sysdep.h
@@ -62,6 +62,24 @@
 typedef ci_int32 ci_uerr_t; /* range of OS user-mode return codes */
 typedef ci_int32 ci_kerr_t; /* range of OS kernel-mode return codes */
 
+#ifndef __DECLARE_FLEX_ARRAY
+#ifndef __cplusplus
+/* linux < 5.16. */
+/* X-SPDX-Source-URL: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git */
+/* X-SPDX-Source-Tag: v5.16 */
+/* X-SPDX-Source-File: include/uapi/linux/stddef.h */
+/* X-SPDX-License-Identifier: GPL-2.0 WITH Linux-syscall-note */
+/* X-SPDX-Comment: Linux 5.16 got this macro to declare flexible arrays.
+ *                 Onload uses it. In order to keep compatibility with
+ *                 older kernels, place the macro here. */
+#define __DECLARE_FLEX_ARRAY(TYPE, NAME)	\
+	struct { \
+		struct { } __empty_ ## NAME; \
+		TYPE NAME[]; \
+	}
+/* X-SPDX-Restore: */
+#endif /* ! __cplusplus */
+#endif /* ! __DECLARE_FLEX_ARRAY */
 
 /**********************************************************************
  * Compiler and processor dependencies.

--- a/src/lib/efrm/efrm_pd.c
+++ b/src/lib/efrm/efrm_pd.c
@@ -90,7 +90,7 @@ struct efrm_pd {
 	/* Buffer table manager.  Needed iff vf==NULL.
 	 * For Huntington, we'll need separate managers for different
 	 * page orders.*/
-	struct efrm_bt_manager bt_managers[0];
+	__DECLARE_FLEX_ARRAY(struct efrm_bt_manager, bt_managers);
 
 	/* !! DANGER !!  Do not add any fields here; bt_managers must be
 	 * the last field.
@@ -112,7 +112,10 @@ struct efrm_pd_owner_ids {
 	 * owner_ids on base VI ID.  On ef10 all owner_ids are 0 based as they
 	 * are function relative. */
 	int base, n;
-	unsigned long used_ids[1];
+	union {
+		unsigned long padding;
+		__DECLARE_FLEX_ARRAY(unsigned long, used_ids);
+	};
 	/* When allocating an owner id block enough memory is allocated to
 	 * continue the used_ids array sufficiently to contain n owner ids.
 	 */

--- a/src/tests/onload/onload_remote_monitor/internal_tests/test_ftl.c
+++ b/src/tests/onload/onload_remote_monitor/internal_tests/test_ftl.c
@@ -155,6 +155,9 @@ int main(int argc, char* argv[])
 #define FTL_TFIELD_ARRAYOFINT(ctx, type, field_name, len, flag) \
   CI_BUILD_ASSERT2( TYPE_TEST((v.field_name), type[len]) );
 
+#define FTL_TFIELD_FLEXARRAYOFSTRUCT(ctx, type, field_name, len, flag, cond) \
+  CI_BUILD_ASSERT2( TYPE_TEST((v.field_name), type[]) );
+
 #define FTL_TFIELD_ARRAYOFSTRUCT(ctx, type, field_name, len, flag, cond) \
   FTL_TFIELD_ARRAYOFINT(ctx, type, field_name, len, flag)
 

--- a/src/tools/onload_remote_monitor/ftl_defs.h
+++ b/src/tools/onload_remote_monitor/ftl_defs.h
@@ -1218,7 +1218,7 @@ typedef struct oo_tcp_socket_stats oo_tcp_socket_stats;
 #define STRUCT_FILTER_TABLE(ctx)                                              \
     FTL_TSTRUCT_BEGIN(ctx, ci_netif_filter_table, )                           \
     FTL_TFIELD_INT(ctx, unsigned, table_size_mask, ORM_OUTPUT_STACK)    \
-    FTL_TFIELD_ARRAYOFSTRUCT(ctx, \
+    FTL_TFIELD_FLEXARRAYOFSTRUCT(ctx, \
 			     ci_netif_filter_table_entry_fast, table, 1, ORM_OUTPUT_STACK, 1) \
     FTL_TSTRUCT_END(ctx)
     

--- a/src/tools/onload_remote_monitor/orm_json_lib.c
+++ b/src/tools/onload_remote_monitor/orm_json_lib.c
@@ -747,6 +747,8 @@ static void orm_dump_struct_ci_netif_config_opts(char* label, ci_netif_config_op
     }                                                                   \
   }
 
+#define FTL_TFIELD_FLEXARRAYOFSTRUCT FTL_TFIELD_ARRAYOFSTRUCT
+
 #define FTL_TFIELD_ANON_STRUCT_BEGIN(ctx, field_name, display_flags) \
      if (output_flags & display_flags) {                                \
       dump_buf_literal("\"" #field_name "\":{");


### PR DESCRIPTION
Since commit 2d47c6956ab3 ("ubsan: Tighten UBSAN_BOUNDS on GCC") in Linux-6.5 we can't use arrays of size [0] or [1] because it triggers UBSAN false-positive warnings "array-index-out-of-bounds".

Use __DECLARE_FLEX_ARRAY() macro to declare flexible arrays in those cases. For arrays with size [1] use a union to keep the size of a struct containing the flexible array unchanged.

---

Depends on #169
Checked on Ubuntu 23.10 `6.5.0-9-generic`