### PR TITLE
Fix objtool warnings

### DIFF
--- a/src/driver/linux_onload/oo_shmbuf.c
+++ b/src/driver/linux_onload/oo_shmbuf.c
@@ -70,30 +70,6 @@ int oo_shmbuf_add(struct oo_shmbuf* sh)
   return i;
 }
 
-unsigned long __oo_shmbuf_ptr2off(const struct oo_shmbuf* sh, char* ptr)
-{
-  int i;
-  unsigned long off;
-
-  /* Fast path is handled at oo_shmbuf_ptr2off().
-   * This function is for slow path only.
-   */
-  off = ptr - oo_shmbuf_idx2ptr(sh, 0);
-  ci_assert(off < 0 || off >= oo_shmbuf_chunk_size(sh) * sh->init_num);
-
-  /* We'd better never hit this path! */
-  ci_assert(0);
-
-  for(i = sh->init_num; i < sh->num; i++) {
-    off = ptr - oo_shmbuf_idx2ptr(sh, i);
-
-    if( off >= 0 && off < oo_shmbuf_chunk_size(sh) )
-      return (i << sh->order << PAGE_SHIFT) + off;
-  }
-  ci_assert(0);
-  return -1;
-}
-
 int oo_shmbuf_fault(struct oo_shmbuf* sh, struct vm_area_struct* vma,
                     unsigned long off)
 {

--- a/src/include/ci/tools/log.h
+++ b/src/include/ci/tools/log.h
@@ -209,7 +209,7 @@ __ci_fail(const char* fmt, ...) CI_PRINTF_LIKE(1,2) CI_HF;
 #define ci_fail(x)							   \
   do{ ci_log("FAIL at %s:%d", __FILE__, __LINE__);  __ci_fail x; }while(0)
 
-extern void __ci_sys_fail(const char* fn, int rc,
+extern CI_NORETURN __ci_sys_fail(const char* fn, int rc,
 			  const char* file, int line) CI_HF;
 #define ci_sys_fail(fn, rc)  __ci_sys_fail(fn, rc, __FILE__, __LINE__)
 

--- a/src/include/onload/oo_shmbuf.h
+++ b/src/include/onload/oo_shmbuf.h
@@ -49,7 +49,6 @@ oo_shmbuf_off2ptr(const struct oo_shmbuf* sh, unsigned long off)
          (off & ((1UL << sh->order << PAGE_SHIFT) - 1));
 }
 
-extern unsigned long __oo_shmbuf_ptr2off(const struct oo_shmbuf* sh, char* ptr);
 static inline unsigned long
 oo_shmbuf_ptr2off(const struct oo_shmbuf* sh, char* ptr)
 {
@@ -61,7 +60,9 @@ oo_shmbuf_ptr2off(const struct oo_shmbuf* sh, char* ptr)
     return off;
 
   /* Slow path: find the pointer in non-continuous chunks */
-  return __oo_shmbuf_ptr2off(sh, ptr);
+  /* We'd better never hit this path! */
+  ci_assert(0);
+  return -1;
 }
 
 static inline long oo_shmbuf_size(struct oo_shmbuf* sh)

--- a/src/lib/citools/fail.c
+++ b/src/lib/citools/fail.c
@@ -69,6 +69,11 @@ CI_NORETURN __ci_fail(const char* fmt, ...)
   ci_backtrace_internal(0);  /* if kernel, don't want duplicate backtrace */
   ci_fail_stop_fn();
 }
+#ifdef STACK_FRAME_NON_STANDARD
+/* Tell objtool to ignore __ci_fail(). It triggers warning:
+ * __ci_fail() falls through to next function ci_backtrace() */
+STACK_FRAME_NON_STANDARD(__ci_fail);
+#endif
 
 
 void ci_backtrace(void)

--- a/src/lib/citools/log_buffer.c
+++ b/src/lib/citools/log_buffer.c
@@ -59,6 +59,11 @@ static CI_NORETURN my_stop_fn(void)
   ci_log_buffer_dump();
   real_stop_fn();
 }
+#ifdef STACK_FRAME_NON_STANDARD
+/* Tell objtool to ignore __ci_fail(). It triggers warning:
+ * my_stop_fn() falls through to next function ci_log_buffer_till_fail() */
+STACK_FRAME_NON_STANDARD(my_stop_fn);
+#endif
 
 
 extern void ci_log_buffer_till_fail(void)

--- a/src/lib/citools/sys_fail.c
+++ b/src/lib/citools/sys_fail.c
@@ -16,7 +16,7 @@
 #include "citools_internal.h"
 
 
-void __ci_sys_fail(const char* fn, int rc, const char* file, int line)
+CI_NORETURN __ci_sys_fail(const char* fn, int rc, const char* file, int line)
 {
   ci_log("*** UNEXPECTED ERROR ***");
   ci_log("        what: %s", fn);


### PR DESCRIPTION
Fix for the #190 

---

Tested by building both user and driver part of Onload on Fedora 38 with `6.5.6-200.fc38.x86_64`
All warnings are gone.