### PR TITLE
Fix build issues on new Linux kernels

### DIFF
--- a/src/driver/linux_onload/onload_kernel_compat.h
+++ b/src/driver/linux_onload/onload_kernel_compat.h
@@ -115,13 +115,17 @@ static inline int efrm_unregister_netdevice_notifier(struct notifier_block *b)
 #define unregister_netdevice_notifier efrm_unregister_netdevice_notifier
 #endif
 
-/* Linux-5.11 introduces lookup_fd_rcu().
- * It was called fcheck() before.
- */
-#ifndef EFRM_HAS_LOOKUP_FD_RCU
-static inline struct file *lookup_fd_rcu(unsigned int fd)
+/* Linux-6.7 introduces lookup_fdget_rcu().
+ * 5.11 >= linux < 6.7 - lookup_fd_rcu().
+ * linux < 5.11 - fcheck(). */
+#ifndef EFRM_HAS_LOOKUP_FDGET_RCU
+static inline struct file *lookup_fdget_rcu(unsigned int fd)
 {
+#ifdef EFRM_HAS_LOOKUP_FD_RCU
+  return lookup_fd_rcu(fd);
+#else
   return fcheck(fd);
+#endif
 }
 #endif
 

--- a/src/driver/linux_onload/ossock_calls.c
+++ b/src/driver/linux_onload/ossock_calls.c
@@ -112,7 +112,7 @@ oo_fd_replace_file(struct file* old_filp, struct file* new_filp,
   }
 
   rcu_read_lock();
-  if( lookup_fd_rcu(old_fd) != old_filp ) {
+  if( lookup_fdget_rcu(old_fd) != old_filp ) {
     rcu_read_unlock();
     spin_unlock(&current->files->file_lock);
     return -EINVAL;

--- a/src/driver/linux_resource/kernel_compat.sh
+++ b/src/driver/linux_resource/kernel_compat.sh
@@ -140,6 +140,7 @@ EFRM_HAS_REMAP_VMALLOC_RANGE_PARTIAL	export	remap_vmalloc_range_partial	include/
 EFRM_HAS_KTIME_GET_REAL_SECONDS	export	ktime_get_real_seconds	include/linux/timekeeping.h	kernel/time/timekeeping.c
 EFRM_FILE_HAS_F_EP	member	struct_file	f_ep	include/linux/fs.h
 EFRM_HAS_LOOKUP_FD_RCU	symbol	lookup_fd_rcu	include/linux/fdtable.h
+EFRM_HAS_LOOKUP_FDGET_RCU	symbol	lookup_fdget_rcu	include/linux/fdtable.h
 
 EFRM_HAS_FLUSH_DELAYED_FPUT	export	flush_delayed_fput	include/linux/file.h	fs/file_table.c
 

--- a/src/driver/linux_resource/kernel_compat.sh
+++ b/src/driver/linux_resource/kernel_compat.sh
@@ -173,6 +173,8 @@ EFRM_HAVE_ITER_IOV symbol iter_iov include/linux/uio.h
 
 EFRM_NEED_DEBUGFS_LOOKUP_AND_REMOVE nsymbol debugfs_lookup_and_remove include/linux/debugfs.h
 
+EFRM_HAVE_WARN_FLUSHING_SYSTEMWIDE_WQ symbol __warn_flushing_systemwide_wq include/linux/workqueue.h
+
 # TODO move onload-related stuff from net kernel_compat
 " | grep -E -v -e '^#' -e '^$' | sed 's/[ \t][ \t]*/:/g'
 }

--- a/src/lib/efhw/af_xdp.c
+++ b/src/lib/efhw/af_xdp.c
@@ -889,7 +889,14 @@ static int af_xdp_init(struct efhw_nic* nic, int instance,
      * socket release to have completed, and try again.
      */
     rcu_barrier();
+#ifdef EFRM_HAVE_WARN_FLUSHING_SYSTEMWIDE_WQ
+    /* linux >= 6.6 forbids flushing system global workqueues.
+     * flush_scheduled_work() is not available anymore for modules, so we use
+     * __flush_workqueue(). */
+    __flush_workqueue(system_wq);
+#else
     flush_scheduled_work();
+#endif
     rc = xdp_bind(sock, nic->net_dev->ifindex, instance, vi->flags);
   }
   if( rc < 0 )

--- a/src/lib/efthrm/tcp_helper_resource.c
+++ b/src/lib/efthrm/tcp_helper_resource.c
@@ -8537,6 +8537,7 @@ void oo_inject_packets_kernel(tcp_helper_resource_t* trs, int sync)
 #include <linux/syscalls.h>
 #include <uapi/linux/bpf.h>
 #include <linux/bpf.h>
+#include <net/xdp.h>
 
 
 ci_inline int oo_xdp_rx_pkt_locked(ci_netif* ni,


### PR DESCRIPTION
Fix compatibility issues introduced by new Linux versions 6.6 and 6.7.

Checked on latest Debian testing (trixie) kernels - 6.6-amd64 and 6.7-amd64 (with HAVE_SFC=0)
Also checked CentOS 8 4.18.0-535.el8.x86_64.