### PR TITLE
linux_onload: do not lock RCU for alloc_fd

### DIFF
--- a/src/driver/linux_onload/ossock_calls.c
+++ b/src/driver/linux_onload/ossock_calls.c
@@ -94,10 +94,8 @@ oo_fd_replace_file(struct file* old_filp, struct file* new_filp,
     unsigned flags;
 
     task_unlock(current);
-    rcu_read_lock(); /* for files_fdtable() */
     flags = close_on_exec(old_fd, files_fdtable(current->files)) ?
             O_CLOEXEC : 0;
-    rcu_read_unlock();
     new_fd = get_unused_fd_flags(flags);
     if( new_fd < 0 ) {
       return new_fd;


### PR DESCRIPTION
There is no need to lock RCU before get_unused_fd_flags() (which boils down to alloc_fd()).  The comment sais that RCU lock in needed for files_fdtable(), but it is not true.  alloc_fd() locks the file_lock spinlock, so it is OK without any additional RCU.

On the flip side, alloc_fd() may call expand_files() which may sleep. So this RCU is both unnecessary and harmful.

Surprisingly it is the only call for get_unused_fd_flags() with RCU lock decoration.  All the other calls are already good, without any additional RCU call.

------

I've seen following Call Trace (seen once, unreproducible):
```
[10215.136270] ------------[ cut here ]------------
[10215.141462] Voluntary context switch within RCU read-side critical section!
[10215.141467] WARNING: CPU: 3 PID: 50035 at kernel/rcu/tree_plugin.h:320 rcu_note_context_switch+0x5e0/0x660
[10215.159186] Modules linked in: onload(OE) sfc_char(OE) sfc_resource(OE) sfc(OE) sfc_driverlink(OE) cts rpcsec_gss_krb5 nfsv4 dns_resolver nfs lockd grace fscache netfs xt_CHECKSUM nft_chain_nat xt_MASQUERADE nf_nat nf_conntrack nf_defrag_ipv6 nf_defrag_ipv4 xt_tcpudp nft_compat bridge nf_tables libcrc32c 8021q garp stp mrp llc binfmt_misc intel_rapl_msr intel_rapl_common sb_edac x86_pkg_temp_thermal intel_powerclamp coretemp kvm_intel kvm irqbypass ghash_clmulni_intel sha512_ssse3 sha512_generic sha256_ssse3 sha1_ssse3 aesni_intel crypto_simd cryptd rapl evdev mgag200 intel_cstate drm_shmem_helper mei_me intel_uncore iTCO_wdt serio_raw acpi_cpufreq intel_pmc_bxt pcspkr drm_kms_helper iTCO_vendor_support mei watchdog ipmi_ssif ioatdma button sg acpi_ipmi ipmi_si ipmi_watchdog ipmi_devintf ipmi_msghandler loop fuse efi_pstore drm dm_mod auth_rpcgss configfs sunrpc nfnetlink ip_tables x_tables autofs4 ext4 crc16 mbcache jbd2 crc32c_generic sd_mod t10_pi crc64_rocksoft crc64 crc_t10dif crct10dif_generic isci libsas ahci
[10215.159273]  libahci scsi_transport_sas ehci_pci ehci_hcd libata crct10dif_pclmul crct10dif_common crc32_pclmul usbcore scsi_mod igb psmouse crc32c_intel i2c_i801 i2c_algo_bit mtd lpc_ich i2c_smbus usb_common dca scsi_common wmi [last unloaded: sfc_driverlink(OE)]
[10215.279456] CPU: 3 PID: 50035 Comm: ta_rpcs Tainted: G        W  OE      6.5.0-5-amd64 #1  Debian 6.5.13-1
[10215.289728] Hardware name: Supermicro X9SRE/X9SRE-3F/X9SRi/X9SRi-3F/X9SRE/X9SRE-3F/X9SRi/X9SRi-3F, BIOS 3.0a 01/03/2014
[10215.301131] RIP: 0010:rcu_note_context_switch+0x5e0/0x660
[10215.307144] Code: 00 00 00 00 0f 85 07 fd ff ff 49 89 8c 24 a0 00 00 00 e9 fa fc ff ff 48 c7 c7 d0 bd 69 89 c6 05 3a 9f a9 01 01 e8 00 8a f4 ff <0f> 0b e9 7b fa ff ff 49 83 bc 24 98 00 00 00 00 49 8b 84 24 a0 00
[10215.327146] RSP: 0018:ffffbaf0006d3a50 EFLAGS: 00010086
[10215.333006] RAX: 0000000000000000 RBX: ffff8e222fcf3fc0 RCX: 0000000000000027
[10215.340782] RDX: ffff8e222fce13c8 RSI: 0000000000000001 RDI: ffff8e222fce13c0
[10215.348547] RBP: 0000000000000000 R08: 0000000000000000 R09: ffffbaf0006d38e0
[10215.356300] R10: 0000000000000003 R11: ffffffff89ebfbe0 R12: ffff8e222fcf31c0
[10215.364052] R13: ffff8e1ec1feb300 R14: ffffbaf0006d3b88 R15: ffffbaf0006d3c38
[10215.371801] FS:  00007ff1b1e61c00(0000) GS:ffff8e222fcc0000(0000) knlGS:0000000000000000
[10215.380504] CS:  0010 DS: 0000 ES: 0000 CR0: 0000000080050033
[10215.386854] CR2: 00007fc0ae25cfc0 CR3: 000000011dd20002 CR4: 00000000000606e0
[10215.394603] Call Trace:
[10215.397666]  <TASK>
[10215.400379]  ? rcu_note_context_switch+0x5e0/0x660
[10215.405771]  ? __warn+0x81/0x130
[10215.409625]  ? rcu_note_context_switch+0x5e0/0x660
[10215.414998]  ? report_bug+0x171/0x1a0
[10215.419237]  ? prb_read_valid+0x1b/0x30
[10215.423644]  ? handle_bug+0x3c/0x80
[10215.427691]  ? exc_invalid_op+0x17/0x70
[10215.432086]  ? asm_exc_invalid_op+0x1a/0x20
[10215.436825]  ? rcu_note_context_switch+0x5e0/0x660
[10215.442158]  __schedule+0xc3/0xb20
[10215.446111]  schedule+0x5e/0xd0
[10215.449783]  schedule_timeout+0x151/0x160
[10215.454336]  wait_for_completion+0x8a/0x160
[10215.459039]  __wait_rcu_gp+0x15b/0x170
[10215.463303]  synchronize_rcu+0x133/0x150
[10215.467741]  ? __pfx_call_rcu_hurry+0x10/0x10
[10215.472598]  ? __pfx_wakeme_after_rcu+0x10/0x10
[10215.477617]  expand_files+0x71/0x230
[10215.481709]  ? tomoyo_path_number_perm+0x8c/0x1f0
[10215.486897]  alloc_fd+0x51/0x170
[10215.490613]  oo_fd_replace_file+0x71/0x160 [onload]
[10215.495994]  efab_tcp_helper_handover+0x159/0x1e0 [onload]
```