### PR TITLE
kcompat: fix file refcounting issue in oo_fd_replace_file()

### DIFF
--- a/src/driver/linux_onload/onload_kernel_compat.h
+++ b/src/driver/linux_onload/onload_kernel_compat.h
@@ -115,18 +115,5 @@ static inline int efrm_unregister_netdevice_notifier(struct notifier_block *b)
 #define unregister_netdevice_notifier efrm_unregister_netdevice_notifier
 #endif
 
-/* Linux-6.7 introduces lookup_fdget_rcu().
- * 5.11 >= linux < 6.7 - lookup_fd_rcu().
- * linux < 5.11 - fcheck(). */
-#ifndef EFRM_HAS_LOOKUP_FDGET_RCU
-static inline struct file *lookup_fdget_rcu(unsigned int fd)
-{
-#ifdef EFRM_HAS_LOOKUP_FD_RCU
-  return lookup_fd_rcu(fd);
-#else
-  return fcheck(fd);
-#endif
-}
-#endif
 
 #endif /* __ONLOAD_KERNEL_COMPAT_H__ */

--- a/src/driver/linux_resource/kernel_compat.sh
+++ b/src/driver/linux_resource/kernel_compat.sh
@@ -124,8 +124,6 @@ EFRM_HAS_REMAP_VMALLOC_RANGE_PARTIAL	export	remap_vmalloc_range_partial	include/
 
 EFRM_HAS_KTIME_GET_REAL_SECONDS	export	ktime_get_real_seconds	include/linux/timekeeping.h	kernel/time/timekeeping.c
 EFRM_FILE_HAS_F_EP	member	struct_file	f_ep	include/linux/fs.h
-EFRM_HAS_LOOKUP_FD_RCU	symbol	lookup_fd_rcu	include/linux/fdtable.h
-EFRM_HAS_LOOKUP_FDGET_RCU	symbol	lookup_fdget_rcu	include/linux/fdtable.h
 
 EFRM_HAS_FLUSH_DELAYED_FPUT	export	flush_delayed_fput	include/linux/file.h	fs/file_table.c
 


### PR DESCRIPTION
Recent linux-6.7 compat patch replaced lookup_fd_rcu() with lookup_fdget_rcu(). They are not identical though, because the latter takes reference to the file.

The patch adds extra fput() and fixes the wrapper to be compatible with older kernels.

Fixes: e34a911603af ("driver: compat for lookup_fd_rcu()")