### PR TITLE
driver/onload: fix spinlock unlocking in error path

### DIFF
--- a/src/driver/linux_onload/ossock_calls.c
+++ b/src/driver/linux_onload/ossock_calls.c
@@ -114,7 +114,7 @@ oo_fd_replace_file(struct file* old_filp, struct file* new_filp,
   rcu_read_lock();
   if( lookup_fdget_rcu(old_fd) != old_filp ) {
     rcu_read_unlock();
-    spin_unlock(&current->files->file_lock);
+    task_unlock(current);
     return -EINVAL;
   }
 


### PR DESCRIPTION
Fix error path in handover code, which handles the case when the file is changing under Onload's feet.  It looks like the error path was not updated when locking schema in all the oo_fd_replace_file() function was changed, and file_lock spin lock was replaced by task_lock.