### PR TITLE
Fix Linux 6.8 build issues

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -146,6 +146,11 @@ $(obj)/src/driver/linux_onload: $(obj)/src/lib/citools $(obj)/src/lib/ciul \
                                 $(obj)/src/lib/transport/ip \
                                 $(obj)/src/lib/cplane mkdirs
 
+# Linux-6.8 turns on -Wmissing-declarations and -Wmissing-prototypes globally.
+# Onload has too many places which trigger those warnings. So, just remove
+# the options to keep build working.
+KBUILD_CFLAGS := $(filter-out -Wmissing-prototypes -Wmissing-declarations, $(KBUILD_CFLAGS))
+
 else
 ################## Top-level makefile
 

--- a/src/driver/linux_resource/filter.c
+++ b/src/driver/linux_resource/filter.c
@@ -663,7 +663,7 @@ find_interface_name( char const* ifname,
                 return 0;
         memset( cur_name, 0, sizeof(efrm_interface_name_t) );
 
-        strlcpy( cur_name->efrm_in_interface_name, ifname, IFNAMSIZ );
+        strscpy( cur_name->efrm_in_interface_name, ifname, IFNAMSIZ );
         cur_name->efrm_in_n_tables = 0;
 
         spin_lock_bh(&efrm_ft_lock);
@@ -787,7 +787,7 @@ efrm_allocate_new_table( char const* dev_name,
 		table->efrm_ft_dev_name = name;
 		table->efrm_ft_interface_name = NULL;
 		if ( dev_name ) {
-			strlcpy( name, dev_name, IFNAMSIZ );
+			strscpy( name, dev_name, IFNAMSIZ );
 		}
 	}
 	return table;
@@ -1966,7 +1966,7 @@ void efrm_map_table( struct net* netns, char const* ifname,
 	}
 	if ( table ) {
 		efrm_add_files( table );
-		strlcpy( table->efrm_ft_dev_name, devname,
+		strscpy( table->efrm_ft_dev_name, devname,
 			 IFNAMSIZ );
 	}
 }

--- a/src/driver/linux_resource/kernel_compat.sh
+++ b/src/driver/linux_resource/kernel_compat.sh
@@ -160,6 +160,8 @@ EFRM_NEED_DEBUGFS_LOOKUP_AND_REMOVE nsymbol debugfs_lookup_and_remove include/li
 
 EFRM_HAVE_WARN_FLUSHING_SYSTEMWIDE_WQ symbol __warn_flushing_systemwide_wq include/linux/workqueue.h
 
+EFRM_HAVE_SET_RXFH_CONTEXT memtype struct_ethtool_ops set_rxfh_context include/linux/ethtool.h int (*)(struct net_device*, const u32*, const u8*, const u8, u32*, bool)
+
 # TODO move onload-related stuff from net kernel_compat
 " | grep -E -v -e '^#' -e '^$' | sed 's/[ \t][ \t]*/:/g'
 }

--- a/src/driver/linux_resource/kernel_proc.c
+++ b/src/driver/linux_resource/kernel_proc.c
@@ -129,7 +129,7 @@ efrm_proc_dir_get(char const* dirname, struct proc_dir_entry* parent,
 		rval->efrm_pd_next = *entry_list_head;
 		rval->efrm_pd_child = NULL;
 		*entry_list_head = rval;
-		strlcpy(rval->efrm_pd_name, dirname, EFRM_PROC_NAME_LEN);
+		strscpy(rval->efrm_pd_name, dirname, EFRM_PROC_NAME_LEN);
 	}
 
 out:
@@ -239,7 +239,7 @@ efrm_proc_create_file( char const* name, mode_t mode, efrm_pd_handle parent,
 		goto done_create_file;
 	}
 	rval->efrm_pf_parent = handle;
-	strlcpy( rval->efrm_pf_name, name, EFRM_PROC_NAME_LEN );
+	strscpy( rval->efrm_pf_name, name, EFRM_PROC_NAME_LEN );
 	rval->efrm_pf_next = handle ? handle->efrm_pd_child : NULL;
 	
 	entry = proc_create_data( name, mode, root, fops, context );


### PR DESCRIPTION
This patch set fixes build on Linux 6.8.

Build works on my `Ubuntu 24.04 (Noble Numbat) 6.8.0-11-generic` setup.
I haven't tested it heavily, just checked tcp connection with netcat on AF_XDP.