### PR TITLE
Unset CC which breaks onload DKMS build

### DIFF
--- a/scripts/onload_misc/dkms.conf
+++ b/scripts/onload_misc/dkms.conf
@@ -7,9 +7,9 @@ PACKAGE_VERSION=
 # We quote make to avoid a misfeature of DKMS which adds a definition
 # of KERNELRELEASE, which should only be defined by kbuild.
 if which onload_uninstall >/dev/null 2>&1; then
-  MAKE[0]="${dkms_tree}/${PACKAGE_NAME}/${PACKAGE_VERSION}/build/scripts/onload_install --newkernel ${kernelver}"
+  MAKE[0]="unset CC; ${dkms_tree}/${PACKAGE_NAME}/${PACKAGE_VERSION}/build/scripts/onload_install --newkernel ${kernelver}"
 else
-  MAKE[0]="${dkms_tree}/${PACKAGE_NAME}/${PACKAGE_VERSION}/build/scripts/onload_install" 
+  MAKE[0]="unset CC; ${dkms_tree}/${PACKAGE_NAME}/${PACKAGE_VERSION}/build/scripts/onload_install"
 fi
 
 #CLEAN="${dkms_tree}/${PACKAGE_NAME}/${PACKAGE_VERSION}/source/scripts/onload_misc/onload_uninstall"


### PR DESCRIPTION
When `CC` is set, it appears to switch into cross-compile mode which breaks the DKMS build.