### PR TITLE
cleanup: fix build for Debian10 4.19 kernel

### DIFF
--- a/src/driver/linux_resource/kernel_compat.sh
+++ b/src/driver/linux_resource/kernel_compat.sh
@@ -156,6 +156,7 @@ EFRM_HUGETLB_HAS_BASEPAGE_INDEX	symbol	hugetlb_basepage_index	include/linux/page
 EFRM_CLASS_CREATE_NO_MODULE symtype class_create include/linux/device/class.h struct class *(const char *)
 
 EFRM_HAVE_ITER_IOV symbol iter_iov include/linux/uio.h
+EFRM_HAVE_IOV_ITER_IS_BVEC symbol iov_iter_is_bvec include/linux/uio.h
 
 EFRM_NEED_DEBUGFS_LOOKUP_AND_REMOVE nsymbol debugfs_lookup_and_remove include/linux/debugfs.h
 

--- a/src/lib/efthrm/tcp_helper_linux.c
+++ b/src/lib/efthrm/tcp_helper_linux.c
@@ -44,6 +44,18 @@ typedef ssize_t(*fop_rw_base_handler)(struct file *filp,
 #define iter_iov(iter) (iter)->iov
 #endif
 
+#ifndef EFRM_HAVE_IOV_ITER_IS_BVEC
+/* Linux < 4.20 */
+ci_inline bool iov_iter_is_bvec(const struct iov_iter *i)
+{
+  return (i->type & ~(READ | WRITE)) == ITER_BVEC;
+}
+ci_inline bool iov_iter_is_pipe(const struct iov_iter *i)
+{
+  return (i->type & ~(READ | WRITE)) == ITER_PIPE;
+}
+#endif
+
 #ifdef EFRM_HAVE_ITER_UBUF
 /* linux >= 6.0
  * See kernel commits


### PR DESCRIPTION
iov_iter_is_bvec() and iov_iter_is_pipe() appeared in 4.20. Make a compat for it.