### PR TITLE
Fix fdtable allocation on new Debian

### DIFF
--- a/src/include/ci/internal/opts_citp_def.h
+++ b/src/include/ci/internal/opts_citp_def.h
@@ -403,6 +403,11 @@ CI_CFG_OPT("EF_FDTABLE_SIZE", fdtable_size, ci_uint32,
 "(help ulimit, man 2 setrlimit) are bound by this value.",
            , , 0, MIN, MAX, count)
 
+CI_CFG_OPT("EF_FDS_MAX", fds_max, ci_uint32,
+"The value which is set as RLIMIT_NOFILE hard limit if the system value "
+"exceeds it. EF_FDTABLE_SIZE overrides it.",
+           , , 1048576, MIN, MAX, count)
+
 #define CI_UL_LOG_E     0x1            /* errors */
 #define CI_UL_LOG_U     0x2            /* unexpected */
 #define CI_UL_LOG_S     0x4            /* setup */

--- a/src/lib/transport/unix/netif_init.c
+++ b/src/lib/transport/unix/netif_init.c
@@ -31,8 +31,6 @@ int citp_netif_init_ctor(void)
 {
   Log_S(ci_log("%s()", __FUNCTION__));
 
-  citp_set_log_level(CITP_OPTS.log_level);
-
   citp_cmn_netif_init_ctor(CITP_OPTS.netif_dtor);
 
   return 0;

--- a/src/lib/transport/unix/startup.c
+++ b/src/lib/transport/unix/startup.c
@@ -583,6 +583,8 @@ citp_transport_init(void)
   if( CITP_OPTS.load_env )
     citp_opts_getenv(&CITP_OPTS);
 
+  citp_set_log_level(CITP_OPTS.log_level);
+
   /* NB. We only look at EF_CONFIG_DUMP if EF_LOAD_ENV. */
   if( CITP_OPTS.load_env && getenv("EF_CONFIG_DUMP") ) {
     citp_dump_opts(&CITP_OPTS);

--- a/src/lib/transport/unix/startup.c
+++ b/src/lib/transport/unix/startup.c
@@ -435,6 +435,7 @@ static void citp_opts_getenv(citp_opts_t* opts)
   GET_ENV_OPT_INT("EF_EPOLL_MT_SAFE",   ul_epoll_mt_safe);
   GET_ENV_OPT_INT("EF_WODA_SINGLE_INTERFACE", woda_single_if);
   GET_ENV_OPT_INT("EF_FDTABLE_SIZE",	fdtable_size);
+  GET_ENV_OPT_INT("EF_FDS_MAX",	fds_max);
   GET_ENV_OPT_INT("EF_SPIN_USEC",	ul_spin_usec);
   GET_ENV_OPT_INT("EF_SLEEP_SPIN_USEC",	sleep_spin_usec);
   GET_ENV_OPT_INT("EF_STACK_PER_THREAD",stack_per_thread);


### PR DESCRIPTION
The first commit fixes #229 
The second one fixes initialization of `citp_log_level`.