### PR TITLE
lib/ip: fix {SND,RCV}BUFFORCE socket options limits

### DIFF
--- a/src/include/ci/internal/ip.h
+++ b/src/include/ci/internal/ip.h
@@ -3117,6 +3117,11 @@ ci_inline int ci_netif_pkt_release_check_keep(ci_netif* ni, ci_ip_pkt_fmt* pkt)
   }
 }
 
+ci_inline ci_uint32 ci_netif_pkt_sets_max_size(ci_netif* ni)
+{
+  return pkt_sets_max(ni) * PKTS_PER_SET * CI_CFG_PKT_BUF_SIZE;
+}
+
 /*********************************************************************
 *************************** pktbuf reserve accounting ****************
 *********************************************************************/

--- a/src/lib/transport/ip/common_sockopts.c
+++ b/src/lib/transport/ip/common_sockopts.c
@@ -1589,7 +1589,7 @@ int ci_set_sol_socket(ci_netif* netif, ci_sock_cmn* s,
     }
     else {
       int lim = CI_MAX((int)NI_OPTS(netif).tcp_sndbuf_max,
-                       netif->packets->sets_max * CI_CFG_PKT_BUF_SIZE / 2);
+                       ci_netif_pkt_sets_max_size(netif) / 2);
       if( v > lim ) {
         NI_LOG_ONCE(netif, RESOURCE_WARNINGS,
                     "SO_SNDBUFFORCE: limiting user-provided value %d to %d.  "
@@ -1625,7 +1625,7 @@ int ci_set_sol_socket(ci_netif* netif, ci_sock_cmn* s,
     }
     else {
       int lim = CI_MAX((int)NI_OPTS(netif).tcp_rcvbuf_max,
-                       netif->packets->sets_max * CI_CFG_PKT_BUF_SIZE / 2);
+                       ci_netif_pkt_sets_max_size(netif) / 2);
       if( v > lim ) {
         NI_LOG_ONCE(netif, RESOURCE_WARNINGS,
                     "SO_RCVBUFFORCE: limiting user-provided value %d to %d.  "

--- a/src/lib/transport/ip/udp_sockopts.c
+++ b/src/lib/transport/ip/udp_sockopts.c
@@ -362,7 +362,7 @@ static int ci_udp_setsockopt_lk(citp_socket* ep, ci_fd_t fd, ci_fd_t os_sock,
         }
         else {
           int lim = CI_MAX((int)NI_OPTS(netif).udp_sndbuf_max,
-                           netif->packets->sets_max * CI_CFG_PKT_BUF_SIZE / 2);
+                           ci_netif_pkt_sets_max_size(netif) / 2);
           if( v > lim ) {
             NI_LOG_ONCE(netif, RESOURCE_WARNINGS,
                         "SO_SNDBUFFORCE: limiting user-provided value %d "
@@ -404,7 +404,7 @@ static int ci_udp_setsockopt_lk(citp_socket* ep, ci_fd_t fd, ci_fd_t os_sock,
         }
         else {
           int lim = CI_MAX((int)NI_OPTS(netif).udp_rcvbuf_max,
-                           netif->packets->sets_max * CI_CFG_PKT_BUF_SIZE / 2);
+                           ci_netif_pkt_sets_max_size(netif) / 2);
           if( v > lim ) {
             NI_LOG_ONCE(netif, RESOURCE_WARNINGS,
                         "SO_RCVBUFFORCE: limiting user-provided value %d "


### PR DESCRIPTION
Fix computing the limits for *_BUFFORCE socket options.
Take into account missing PKTS_PER_SET constant.