### PR TITLE
lib/ip: calculate SO_RCVBUFFORCE limit more accurately

### DIFF
--- a/src/include/ci/internal/ip.h
+++ b/src/include/ci/internal/ip.h
@@ -3117,9 +3117,23 @@ ci_inline int ci_netif_pkt_release_check_keep(ci_netif* ni, ci_ip_pkt_fmt* pkt)
   }
 }
 
-ci_inline ci_uint32 ci_netif_pkt_sets_max_size(ci_netif* ni)
+/* Functions below are used to compute maximum socket buffer size limit when
+ * setting it via RCVBUFFORCE/SNDBUFFORCE socket options. The aim is to not
+ * allow user to set a buffer big enough to let a single socket grab all the
+ * packets available for the stack.
+ * Additionally, the returned value must be halved before comparing with user's
+ * request to behave as Linux. See usage in ci_set_sol_socket() and
+ * ci_udp_setsockopt_lk(). */
+ci_inline ci_uint32 ci_netif_max_rx_packets_size_per_socket(const ci_netif* ni)
 {
-  return pkt_sets_max(ni) * PKTS_PER_SET * CI_CFG_PKT_BUF_SIZE;
+  /* Allow only 1/5 of all packets for rx socket buffer. Keep the rest for other
+   * sockets and rx ring. */
+  return NI_OPTS(ni).max_rx_packets * CI_CFG_PKT_BUF_SIZE / 5;
+}
+ci_inline ci_uint32 ci_netif_max_tx_packets_size_per_socket(const ci_netif* ni)
+{
+  /* Use '/4' for tx socket buffer as we don't have such strict constraints. */
+  return NI_OPTS(ni).max_tx_packets * CI_CFG_PKT_BUF_SIZE / 4;
 }
 
 /*********************************************************************

--- a/src/lib/transport/ip/common_sockopts.c
+++ b/src/lib/transport/ip/common_sockopts.c
@@ -1595,7 +1595,7 @@ int ci_set_sol_socket(ci_netif* netif, ci_sock_cmn* s,
     }
     else {
       int lim = CI_MAX((int)NI_OPTS(netif).tcp_sndbuf_max,
-                       ci_netif_pkt_sets_max_size(netif) / 2);
+                       ci_netif_max_tx_packets_size_per_socket(netif) / 2);
       if( v > lim ) {
         NI_LOG_ONCE(netif, RESOURCE_WARNINGS,
                     "SO_SNDBUFFORCE: limiting user-provided value %d to %d.  "
@@ -1631,7 +1631,7 @@ int ci_set_sol_socket(ci_netif* netif, ci_sock_cmn* s,
     }
     else {
       int lim = CI_MAX((int)NI_OPTS(netif).tcp_rcvbuf_max,
-                       ci_netif_pkt_sets_max_size(netif) / 2);
+                       ci_netif_max_rx_packets_size_per_socket(netif) / 2);
       if( v > lim ) {
         NI_LOG_ONCE(netif, RESOURCE_WARNINGS,
                     "SO_RCVBUFFORCE: limiting user-provided value %d to %d.  "

--- a/src/lib/transport/ip/udp_sockopts.c
+++ b/src/lib/transport/ip/udp_sockopts.c
@@ -370,7 +370,7 @@ static int ci_udp_setsockopt_lk(citp_socket* ep, ci_fd_t fd, ci_fd_t os_sock,
         }
         else {
           int lim = CI_MAX((int)NI_OPTS(netif).udp_sndbuf_max,
-                           ci_netif_pkt_sets_max_size(netif) / 2);
+                           ci_netif_max_tx_packets_size_per_socket(netif) / 2);
           if( v > lim ) {
             NI_LOG_ONCE(netif, RESOURCE_WARNINGS,
                         "SO_SNDBUFFORCE: limiting user-provided value %d "
@@ -412,7 +412,7 @@ static int ci_udp_setsockopt_lk(citp_socket* ep, ci_fd_t fd, ci_fd_t os_sock,
         }
         else {
           int lim = CI_MAX((int)NI_OPTS(netif).udp_rcvbuf_max,
-                           ci_netif_pkt_sets_max_size(netif) / 2);
+                           ci_netif_max_rx_packets_size_per_socket(netif) / 2);
           if( v > lim ) {
             NI_LOG_ONCE(netif, RESOURCE_WARNINGS,
                         "SO_RCVBUFFORCE: limiting user-provided value %d "


### PR DESCRIPTION
Do not allow socket receive buffer size to exceed maximum number of RX packets.