### PR TITLE
Fix root makefile to work with linux 6.10

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -282,7 +282,26 @@ clean_kernel:
 # Can't figure out a way to get modpost to look in the src directory. At least
 # the number of makefiles is much smaller than the number of source files
 $(OUTMAKEFILES): $(KBUILDTOP)/%: %
-	$(Q)mkdir -p $(@D)
 	$(Q)ln -sf `realpath '--relative-to=$(@D)' '$<'` $@
+
+# Linux 6.10 build fix: place symlinks to source files into the build directory.
+# See github issue #236.
+DRIVER_BUILD_SUBDIRS_ALL := $(foreach D,$(DRIVER_SUBDIRS),$(KBUILDTOP)/$(D))
+DRIVER_BUILD_SUBDIRS_ALL += $(KBUILDTOP)/src/lib/efthrm
+DRIVER_BUILD_SUBDIRS_ALL += $(KBUILDTOP)/src/lib/efhw
+DRIVER_BUILD_SUBDIRS_ALL += $(KBUILDTOP)/src/lib/efrm
+DRIVER_BUILD_SUBDIRS_ALL += $(KBUILDTOP)/src/lib/kernel_utils
+ifeq ($(HAVE_SFC),1)
+DRIVER_BUILD_SUBDIRS_ALL += $(KBUILDTOP)/src/lib/efhw/ef10
+endif
+ifeq ($(HAVE_EF10CT),1)
+DRIVER_BUILD_SUBDIRS_ALL += $(KBUILDTOP)/src/lib/efhw/ef10ct
+endif
+
+$(OUTMAKEFILES): $(DRIVER_BUILD_SUBDIRS_ALL)
+
+$(DRIVER_BUILD_SUBDIRS_ALL): $(KBUILDTOP)/%: %
+	$(Q)mkdir -p $@
+	$(Q)ln -rsf $(wildcard $</*.[ch]) $@
 
 endif  # ifeq ($(KERNELRELEASE),)


### PR DESCRIPTION
Linux 6.10 has broken Onload kernel modules build by replacing $(src) with $(obj) in its makefiles.
See Linux commit 9a0ebe5011f49e932bb0a2cea2034fd65e6e567e

This patch implements a possible approach - create symlinks to Onload source files in build directory.

---

Possible fix for #236
Checked on CentOS 9 `6.10.5-1.el9.elrepo.x86_64` and Ubuntu 22.04 `6.8.0-40-generic` by running `make`/ `mmakebuildtree --driver && make`.

Note: there are other build issues, related to linux-6.10, which I'll address separately.