### PR TITLE
make: add capability to use old-style driver build

### DIFF
--- a/scripts/mmakebuildtree
+++ b/scripts/mmakebuildtree
@@ -190,6 +190,7 @@ while [ $# -gt 0 ]; do
     -b|--build-dir) if [ -z "$2" ]; then usage; fi; builddir="$2";  shift;;
     --driver) driver=1; newdriver=1;;
     --newdriver) driver=1; newdriver=1;;
+    --olddriver) driver=1;;
     --gnu|--user) gnu=1;;
     --cc) CC="$2"; shift;;
     --help | -*) usage;;


### PR DESCRIPTION
It can be used as a workaround in cases when new build system does not work for some reasons.