### PR TITLE
linux-6.10: add compat for follow_pte()

### DIFF
--- a/src/driver/linux_resource/kernel_compat.sh
+++ b/src/driver/linux_resource/kernel_compat.sh
@@ -174,6 +174,7 @@ EFRM_CLOEXEC_FILES_STRUCT	symtype	close_on_exec	include/linux/fdtable.h	bool(uns
 EFRM_HAVE_FOLLOW_PFNMAP_START symbol follow_pfnmap_start include/linux/mm.h
 
 EFRM_HAVE_FOLLOW_PTE symbol follow_pte include/linux/mm.h
+EFRM_HAVE_FOLLOW_PTE_VMA symtype follow_pte include/linux/mm.h int(struct vm_area_struct*, unsigned long, pte_t**, spinlock_t**)
 
 # TODO move onload-related stuff from net kernel_compat
 " | grep -E -v -e '^#' -e '^$' | sed 's/[ \t][ \t]*/:/g'

--- a/src/include/ci/driver/kernel_compat.h
+++ b/src/include/ci/driver/kernel_compat.h
@@ -502,6 +502,15 @@ static inline int efrm_follow_pfn(struct vm_area_struct *vma,
 }
 #elif defined(EFRM_HAVE_FOLLOW_PTE)
 /* exported in linux 5.10+ */
+
+#ifdef EFRM_HAVE_FOLLOW_PTE_VMA
+/* linux >= 6.10 */
+#define efrm_follow_pte follow_pte
+#else
+#define efrm_follow_pte(vma, addr, ptep, ptl) \
+  follow_pte(vma->vm_mm, addr, ptep, ptl)
+#endif /* EFRM_HAVE_FOLLOW_PTE_VMA */
+
 static inline int efrm_follow_pfn(struct vm_area_struct *vma,
                                   unsigned long addr, unsigned long *pfn)
 {
@@ -514,7 +523,7 @@ static inline int efrm_follow_pfn(struct vm_area_struct *vma,
 	if( !(vma->vm_flags & (VM_IO | VM_PFNMAP)) )
 		return -EINVAL;
 
-	rc = follow_pte(vma->vm_mm, addr, &ptep, &ptl);
+	rc = efrm_follow_pte(vma, addr, &ptep, &ptl);
 	if( rc == 0 ) {
 		*pfn = pte_pfn(ptep_get(ptep));
 		pte_unmap_unlock(ptep, ptl);


### PR DESCRIPTION
The function prototype has been changed in linux 6.10. Support both variants to be able to run Onload on kernels 6.10 and 6.11.