### PR TITLE
af_xdp: move rx timestamp read to support WODA

### DIFF
--- a/src/lib/transport/ip/netif_event.c
+++ b/src/lib/transport/ip/netif_event.c
@@ -221,26 +221,6 @@ static void get_rx_timestamp(ci_netif* netif, ci_ip_pkt_fmt* pkt)
   ci_netif_state_nic_t* nsn = &netif->state->nic[pkt->intf_i];
   ef_vi* vi = ci_netif_vi(netif, pkt->intf_i);
 
-  /* AF_XDP timestamps are read in ci_netif_poll_evq
-   * TODO: probably move here. we have all necessary data: vi and pkt */
-  if( vi->nic_type.arch == EF_VI_ARCH_AF_XDP ) {
-    struct onload_xdp_rx_meta {
-#define ONLOAD_XDP_RX_META_TSTAMP 0x1
-      uint64_t flags;
-      uint64_t tstamp;
-    } *meta;
-    const uint64_t ns_to_sec = 1000UL * 1000 * 1000;
-
-    meta = ((struct onload_xdp_rx_meta *)(pkt->dma_start + pkt->pkt_start_off)) - 1;
-    if (meta->flags & ONLOAD_XDP_RX_META_TSTAMP) {
-      pkt->hw_stamp.tv_sec = meta->tstamp / ns_to_sec;
-      pkt->hw_stamp.tv_nsec = meta->tstamp % ns_to_sec;
-      pkt->hw_stamp.tv_nsec_frac = 0;
-      pkt->hw_stamp.tv_flags = 0;
-    }
-    return;
-  }
-
   if( (vi->nic_type.arch != EF_VI_ARCH_EFCT) &&
       (nsn->oo_vi_flags & OO_VI_FLAGS_RX_HW_TS_EN) ) {
     ef_precisetime stamp;


### PR DESCRIPTION
Move AF_XDP rx timestamp read into vi->ops.receive_get_timestamp.

The original implementation added a branch in device independent get_rx_timestamp. This is not needed, and it breaks WODA, because record_rx_timestamp is skipped.

Fix this, and as a side-effect better isolate the AF_XDP from the device independent code.

WODA also needs the EF_VI_SYNC flags passed. XDP offers no way to query the device for these currently. Similar to ef10_mcdi_event, assume clock is always in sync.

With this change, src/tests/onload/wire_order succeeds.