### PR TITLE
driver/onload: do not run useless code in page-fault handler

### DIFF
--- a/src/driver/linux_onload/oo_shmbuf.c
+++ b/src/driver/linux_onload/oo_shmbuf.c
@@ -76,7 +76,6 @@ int oo_shmbuf_fault(struct oo_shmbuf* sh, struct vm_area_struct* vma,
   int i = off >> sh->order >> PAGE_SHIFT;
   unsigned long start_off = (unsigned long)i << sh->order << PAGE_SHIFT;
   unsigned long size = oo_shmbuf_chunk_size(sh);
-  int rc;
 
   ci_assert_lt(i, sh->max);
   if( sh->addrs[i] == 0 )
@@ -88,10 +87,6 @@ int oo_shmbuf_fault(struct oo_shmbuf* sh, struct vm_area_struct* vma,
     size *= sh->init_num;
   }
 
-  rc = oo_remap_vmalloc_range_partial(vma, vma->vm_start + start_off,
-                                      (void*)sh->addrs[i], size);
-  if( rc >= 0 )
-    /* remap_vmalloc_range_partial sets this */
-    vm_flags_clear(vma, VM_DONTDUMP);
-  return rc;
+  return oo_remap_vmalloc_range_partial(vma, vma->vm_start + start_off,
+                                        (void*)sh->addrs[i], size);
 }

--- a/src/include/ci/driver/kernel_compat.h
+++ b/src/include/ci/driver/kernel_compat.h
@@ -389,11 +389,17 @@ oo_remap_vmalloc_range_partial(struct vm_area_struct *vma, unsigned long uaddr,
 {
 #ifdef EFRM_HAS_REMAP_VMALLOC_RANGE_PARTIAL
   /* linux<5.13 */
-  return remap_vmalloc_range_partial(vma, uaddr, kaddr,
+  int rc = remap_vmalloc_range_partial(vma, uaddr, kaddr,
 #ifdef EFRM_REMAP_VMALLOC_RANGE_PARTIAL_NEW
                                      0 /*pgoff, in linux>=5.7 */,
 #endif
                                      size);
+
+  if( rc >= 0 )
+    /* remap_vmalloc_range_partial sets this */
+    vm_flags_clear(vma, VM_DONTDUMP);
+
+  return rc;
 #else
   /* linux>=5.13 */
   unsigned long npages = size >> PAGE_SHIFT;


### PR DESCRIPTION
Do not try to clear VM_DONTDUMP flag, which is not set. Move vm_flags_clear() to the corresponding compat code to make it run only after remap_vmalloc_range_partial().

It helps to avoid locking issues with new kernels. vm_flags_clear() triggers a WARNING now:
WARNING: CPU: 3 PID: 36069 at include/linux/rwsem.h:85 oo_shmbuf_fault+0x27e/0x2b0 [onload]

See related Linux commit:
ba168b52bf8ecb877af294769b0ab32b06bd9293