### PR TITLE
lib/ip: fix build for debug kernel

### DIFF
--- a/src/lib/transport/ip/udp_send.c
+++ b/src/lib/transport/ip/udp_send.c
@@ -126,8 +126,9 @@ static bool ci_ipx_is_mf_set(int af, ci_ipx_hdr_t* ipx)
 ci_noinline void ci_udp_sendmsg_chksum(ci_netif* ni, ci_ip_pkt_fmt* pkt,
                                        int af, ci_ipx_hdr_t* first_hdr)
 {
-  /* 1400*50 = 70000, i.e. in normal situation there are <50 fragments */
-#define MAX_IP_FRAGMENTS 50
+  /* 1428*46 = 65688 > 65536, i.e. in normal situation there are <=46
+   * fragments */
+#define MAX_IP_FRAGMENTS 46
   struct iovec iov[MAX_IP_FRAGMENTS];
   int n = -1;
   ci_udp_hdr* udp = TX_PKT_IPX_UDP(af, pkt, true);


### PR DESCRIPTION
Make on-stack array smaller to avoid warning when building for a kernel with a lot of debug features enabled.  Decrease the maximum number of IP fragments per UDP packet from 50 to 46 (and send larger datagrams without checksum).

----
Without this patch I see following issue with my debug kernel:
```
/home/sasha/work/level5/onload/src/lib/transport/ip/udp_send.c: In function ‘ci_udp_sendmsg_chksum.constprop’:
/home/sasha/work/level5/onload/src/lib/transport/ip/udp_send.c:201:1: error: the frame size of 1088 bytes is larger than 1024 bytes [-Werror=frame-larger-than=]
  201 | }
      | ^
```

I believe that nobody uses IP fragmentation nowadays, so a small regression (Onload stops from providing UDP checksum when a packet is fragmented into >46 IP fragments) is acceptable.  However I have no strong opinion on this issue.