### PR TITLE
sfc_resource: avoid memory leak after debugfs files removal

### DIFF
--- a/src/driver/linux_resource/debugfs.c
+++ b/src/driver/linux_resource/debugfs.c
@@ -20,16 +20,12 @@ struct efrm_debugfs_bound_param {
 
 
 #ifdef EFRM_NEED_DEBUGFS_LOOKUP_AND_REMOVE
+/* Compat for linux<5.19. */
 void debugfs_lookup_and_remove(const char *name, struct dentry *dir)
 {
-  struct qstr child_name = QSTR_INIT(name, strlen(name));
-  struct dentry *child;
+  struct dentry *child = debugfs_lookup(name, dir);
 
-  child = d_hash_and_lookup(dir, &child_name);
-  if (!IS_ERR_OR_NULL(child)) {
-    /* If it's a "regular" file, free its parameter binding */
-    if (S_ISREG(child->d_inode->i_mode))
-    kfree(child->d_inode->i_private);
+  if (child) {
     debugfs_remove(child);
     dput(child);
   }

--- a/src/driver/linux_resource/debugfs.h
+++ b/src/driver/linux_resource/debugfs.h
@@ -113,8 +113,10 @@ extern int efrm_debugfs_read_string(struct seq_file *, const void *);
 }
 
 
-extern void efrm_init_debugfs_files(struct dentry *parent,
-                       const struct efrm_debugfs_parameter *params, void *ref);
+extern void efrm_init_debugfs_files(struct efrm_debugfs_dir *debug_dir,
+                       const struct efrm_debugfs_parameter *params,
+                       void *ref);
+extern void efrm_fini_debugfs_files(struct efrm_debugfs_dir *debug_dir);
 
 #endif /* CONFIG_DEBUG_FS */
 

--- a/src/include/ci/efhw/ef10ct.h
+++ b/src/include/ci/efhw/ef10ct.h
@@ -91,7 +91,7 @@ struct efhw_nic_ef10ct {
     struct mutex lock;
   } vi_allocator;
   struct efct_filter_state filter_state;
-  struct dentry* debug_dir;
+  struct efrm_debugfs_dir debug_dir;
   struct xarray irqs;
   struct mutex irq_lock;
 };

--- a/src/include/ci/efhw/efct.h
+++ b/src/include/ci/efhw/efct.h
@@ -251,7 +251,7 @@ struct efhw_nic_efct {
   /* ZF emu includes this file from UL */
 #ifdef __KERNEL__
   struct efct_filter_state filter_state;
-  struct dentry* debug_dir;
+  struct efrm_debugfs_dir debug_dir;
 #endif
   struct {
     struct efhw_stack_allocator alloc;

--- a/src/include/ci/efhw/efhw_types.h
+++ b/src/include/ci/efhw/efhw_types.h
@@ -573,6 +573,11 @@ struct efhw_func_ops {
 
 struct pci_dev;
 
+struct efrm_debugfs_dir {
+	struct dentry *dir;
+	void *bindings;
+};
+
 /*! */
 struct efhw_nic {
 	/*! zero base index in efrm_nic_tablep->nic array */
@@ -699,7 +704,7 @@ struct efhw_nic {
         /* TX datapath firmware variant */
         uint16_t tx_variant;
 
-	struct dentry *debug_dir;
+	struct efrm_debugfs_dir debug_dir;
 	struct dentry *rs_debug_dirs[EFRM_RESOURCE_NUM];
 
         /* arch-specific state */

--- a/src/include/ci/efrm/resource.h
+++ b/src/include/ci/efrm/resource.h
@@ -70,7 +70,7 @@ struct efrm_resource {
 	struct efrm_client *rs_client;
 	struct list_head rs_client_link;
 	struct list_head rs_manager_link;
-	struct dentry *debug_dir;
+	struct efrm_debugfs_dir debug_dir;
 	/* debugfs folders for any resources that sit beneath this in
 	 * resource debug folder hierarchy. */
 	struct dentry *rs_debug_dirs[EFRM_RESOURCE_NUM];

--- a/src/lib/efhw/debugfs_efct.c
+++ b/src/lib/efhw/debugfs_efct.c
@@ -113,10 +113,10 @@ void efhw_init_debugfs_efct(struct efhw_nic *nic)
   struct efhw_nic_efct *efct = (struct efhw_nic_efct *) nic->arch_extra;
 
   /* Create directory */
-  efct->debug_dir = debugfs_create_dir("efct", nic->debug_dir);
+  efct->debug_dir.dir = debugfs_create_dir("efct", nic->debug_dir.dir);
 
   /* Create files */
-  efrm_init_debugfs_files(efct->debug_dir, efhw_debugfs_efct_parameters, efct);
+  efrm_init_debugfs_files(&efct->debug_dir, efhw_debugfs_efct_parameters, efct);
 }
 
 /**
@@ -129,8 +129,7 @@ void efhw_fini_debugfs_efct(struct efhw_nic *nic)
 {
   struct efhw_nic_efct *efct = (struct efhw_nic_efct *) nic->arch_extra;
 
-  debugfs_remove_recursive(efct->debug_dir);
-  efct->debug_dir = NULL;
+  efrm_fini_debugfs_files(&efct->debug_dir);
 }
 
 static const struct efrm_debugfs_parameter efhw_debugfs_ef10ct_parameters[] = {
@@ -152,10 +151,10 @@ void efhw_init_debugfs_ef10ct(struct efhw_nic *nic)
   struct efhw_nic_ef10ct *ef10ct = (struct efhw_nic_ef10ct *) nic->arch_extra;
 
   /* Create directory */
-  ef10ct->debug_dir = debugfs_create_dir("ef10ct", nic->debug_dir);
+  ef10ct->debug_dir.dir = debugfs_create_dir("ef10ct", nic->debug_dir.dir);
 
   /* Create files */
-  efrm_init_debugfs_files(ef10ct->debug_dir, efhw_debugfs_ef10ct_parameters, ef10ct);
+  efrm_init_debugfs_files(&ef10ct->debug_dir, efhw_debugfs_ef10ct_parameters, ef10ct);
 }
 
 /**
@@ -168,8 +167,7 @@ void efhw_fini_debugfs_ef10ct(struct efhw_nic *nic)
 {
   struct efhw_nic_ef10ct *ef10ct = (struct efhw_nic_ef10ct *) nic->arch_extra;
 
-  debugfs_remove_recursive(ef10ct->debug_dir);
-  ef10ct->debug_dir = NULL;
+  efrm_fini_debugfs_files(&ef10ct->debug_dir);
 }
 
 #else /* !CONFIG_DEBUG_FS */

--- a/src/lib/efhw/debugfs_nic.c
+++ b/src/lib/efhw/debugfs_nic.c
@@ -144,10 +144,10 @@ void efhw_init_debugfs_nic(struct efhw_nic *nic)
            nic->net_dev->name);
 
   /* Create directory */
-  nic->debug_dir = debugfs_create_dir(dir_name, efrm_debug_nics);
+  nic->debug_dir.dir = debugfs_create_dir(dir_name, efrm_debug_nics);
 
   /* Create files */
-  efrm_init_debugfs_files(nic->debug_dir, efhw_debugfs_nic_parameters, nic);
+  efrm_init_debugfs_files(&nic->debug_dir, efhw_debugfs_nic_parameters, nic);
 }
 
 /**
@@ -158,8 +158,7 @@ void efhw_init_debugfs_nic(struct efhw_nic *nic)
  */
 void efhw_fini_debugfs_nic(struct efhw_nic *nic)
 {
-  debugfs_remove_recursive(nic->debug_dir);
-  nic->debug_dir = NULL;
+  efrm_fini_debugfs_files(&nic->debug_dir);
   memset(nic->rs_debug_dirs, 0, sizeof(nic->rs_debug_dirs));
 }
 

--- a/src/lib/efrm/debugfs_rs.c
+++ b/src/lib/efrm/debugfs_rs.c
@@ -56,13 +56,13 @@ void efrm_debugfs_add_rs(struct efrm_resource *rs,
 		EFRM_ASSERT(parent_rs->rs_client);
 		EFRM_ASSERT(parent_rs->rs_client->nic);
 		EFRM_ASSERT(parent_rs->rs_client->nic == rs->rs_client->nic);
-		parent = parent_rs->debug_dir;
+		parent = parent_rs->debug_dir.dir;
 		rs_debug_dirs = parent_rs->rs_debug_dirs;
 	}
 	else {
 		/* No parent, use nic debug_dir */
 		struct efhw_nic *nic = rs->rs_client->nic;
-		parent = nic->debug_dir;
+		parent = nic->debug_dir.dir;
 		rs_debug_dirs = nic->rs_debug_dirs;
 	}
 
@@ -73,7 +73,7 @@ void efrm_debugfs_add_rs(struct efrm_resource *rs,
 			return;
 	}
 	snprintf(name, sizeof(name), "%d", id);
-	rs->debug_dir = debugfs_create_dir(name, rs_debug_dirs[rs->rs_type]);
+	rs->debug_dir.dir = debugfs_create_dir(name, rs_debug_dirs[rs->rs_type]);
 }
 
 /**
@@ -82,10 +82,8 @@ void efrm_debugfs_add_rs(struct efrm_resource *rs,
  */
 void efrm_debugfs_remove_rs(struct efrm_resource *rs)
 {
-	/* debugfs_remove is ok to pass ERR_OR_NULL here */
-	debugfs_remove_recursive(rs->debug_dir);
+	efrm_fini_debugfs_files(&rs->debug_dir);
 	memset(rs->rs_debug_dirs, 0, sizeof(rs->rs_debug_dirs));
-	rs->debug_dir = NULL;
 }
 
 /**
@@ -98,7 +96,7 @@ void efrm_debugfs_add_rs_files(struct efrm_resource *rs,
 	                       const struct efrm_debugfs_parameter *parameters,
 	                       void *ref)
 {
-	efrm_init_debugfs_files(rs->debug_dir, parameters, ref);
+	efrm_init_debugfs_files(&rs->debug_dir, parameters, ref);
 }
 #else /* !CONFIG_DEBUG_FS */
 void efrm_debugfs_add_rs(struct efrm_resource *rs,

--- a/src/lib/efrm/efrm_internal.h
+++ b/src/lib/efrm/efrm_internal.h
@@ -47,7 +47,7 @@ static inline void efrm_resource_init(struct efrm_resource *rs,
 	rs->rs_type = type;
 	rs->rs_instance = instance;
 	rs->rs_client = NULL;
-	rs->debug_dir = NULL;
+	memset(&rs->debug_dir, 0, sizeof(rs->debug_dir));
 	memset(rs->rs_debug_dirs, 0, sizeof(rs->rs_debug_dirs));
 }
 


### PR DESCRIPTION
Store debugfs file bindings pointer in a NIC associated structure and free this memory at cleanup. It isn't released by kernel, causing memory leak after module unloading.