### PR TITLE
compat: avoid fortify memcpy/memmove warnings on linux>=6.11

### DIFF
--- a/src/include/ci/tools/sysdep.h
+++ b/src/include/ci/tools/sysdep.h
@@ -77,6 +77,24 @@ typedef ci_int32 ci_kerr_t; /* range of OS kernel-mode return codes */
 #define PTR_ERR_OR_ZERO(ptr) (IS_ERR(ptr) ? PTR_ERR(ptr) : 0)
 #define ERR_PTR(err) ((void*)(uintptr_t)(long)(err))
 
+#ifndef unsafe_memcpy
+#define unsafe_memcpy(dst, src, bytes, justification) memcpy(dst, src, bytes)
+#endif
+
+#ifndef unsafe_memmove
+/* Unlike unsafe_memcpy(), kernel does not provide unsafe_memmove(). */
+#ifdef __KERNEL__
+#define unsafe_memmove(dst, src, bytes, justification) \
+	__underlying_memmove(dst, src, bytes)
+#ifndef __underlying_memmove
+/* __underlying_memmove() was undefined in linux<5.18. */
+#define __underlying_memmove __builtin_memmove
+#endif /* __underlying_memmove */
+#else
+#define unsafe_memmove(dst, src, bytes, justification) memmove(dst, src, bytes)
+#endif /* __KERNEL__ */
+#endif /* ! unsafe_memmove */
+
 /**********************************************************************
  * Compiler and processor dependencies.
  */

--- a/src/lib/transport/ip/csum_copy_iovec_setlen.c
+++ b/src/lib/transport/ip/csum_copy_iovec_setlen.c
@@ -23,7 +23,7 @@ ci_inline int do_copy_from_user(void* to, const void* from, int n_bytes
   if( addr_spc != CI_ADDR_SPC_KERNEL )
     return copy_from_user(to, from, n_bytes);
 #endif
-  memcpy(to, from, n_bytes);
+  unsafe_memcpy(to, from, n_bytes, "variable length dest struct");
   return 0;
 }
 

--- a/src/lib/transport/ip/tcp_misc.c
+++ b/src/lib/transport/ip/tcp_misc.c
@@ -1057,7 +1057,8 @@ static int ci_tcp_rx_pkt_coalesce(ci_netif* ni, ci_ip_pkt_queue* q,
   /* Move contents of packet to the beginning of the buffer. */
   if( oo_offbuf_ptr(pkt_buf) != pkt_payload ) {
     int n = (int)(oo_offbuf_ptr(pkt_buf) - pkt_payload);
-    memmove(pkt_payload, oo_offbuf_ptr(pkt_buf), oo_offbuf_left(pkt_buf));
+    unsafe_memmove(pkt_payload, oo_offbuf_ptr(pkt_buf), oo_offbuf_left(pkt_buf),
+                   "variable length dest struct");
     pkt_buf->off -= n;
     pkt_buf->end -= n;
     pkt_tcp->tcp_seq_be32 = CI_BSWAP_BE32(

--- a/src/lib/transport/ip/tcp_tx_reformat.c
+++ b/src/lib/transport/ip/tcp_tx_reformat.c
@@ -64,10 +64,10 @@ static int ci_tcp_tx_merge_segment(ci_netif* ni, ci_ip_pkt_fmt* dest_pkt,
   if( do_copy ) {
     if( dest_pkt == src_pkt ) {
       /* Same packet: may be overlapping. */
-      memmove(dest, src, n);
+      unsafe_memmove(dest, src, n, "variable length dest struct");
     }
     else
-      memcpy(dest, src, n);
+      unsafe_memcpy(dest, src, n, "variable length dest struct");
   }
 
   dest_pkt->buf_len += n;


### PR DESCRIPTION
Avoid false-positive warnings like:
memcpy: detected field-spanning write (size 1436) of single field "dest" at src/lib/transport/ip/tcp_tx_reformat.c:74 (size 0)

Since actual allocation is bigger than ci_ip_pkt_fmt struct size, it is safe to copy beyond the struct.
Use unsafe_memcpy()/unsafe_memmove() for copying to ci_ip_pkt_fmt struct in a few places, which trigger the warning:
ci_tcp_tx_merge_segment(), ci_tcp_rx_pkt_coalesce() and do_copy_from_user().