### PR TITLE
Fix linux-6.12 support

### DIFF
--- a/src/driver/linux_onload/ossock_calls.c
+++ b/src/driver/linux_onload/ossock_calls.c
@@ -655,14 +655,12 @@ int efab_tcp_helper_create_os_sock(ci_private_t *priv)
   sock = get_linux_socket(ep);
 
   /* Copy F_SETOWN_EX, F_SETSIG to the new file */
-#ifdef F_SETOWN_EX
   if(efrm_file_f_owner(priv->_filp)->pid != 0) {
     rcu_read_lock();
     __f_setown(sock->file, efrm_file_f_owner(priv->_filp)->pid,
                efrm_file_f_owner(priv->_filp)->pid_type, 1);
     rcu_read_unlock();
   }
-#endif
   efrm_file_f_owner(sock->file)->signum =
                                efrm_file_f_owner(priv->_filp)->signum;
 

--- a/src/driver/linux_onload/ossock_calls.c
+++ b/src/driver/linux_onload/ossock_calls.c
@@ -655,14 +655,11 @@ int efab_tcp_helper_create_os_sock(ci_private_t *priv)
   sock = get_linux_socket(ep);
 
   /* Copy F_SETOWN_EX, F_SETSIG to the new file */
-  if(efrm_file_f_owner(priv->_filp)->pid != 0) {
-    rcu_read_lock();
-    __f_setown(sock->file, efrm_file_f_owner(priv->_filp)->pid,
-               efrm_file_f_owner(priv->_filp)->pid_type, 1);
-    rcu_read_unlock();
+  rc = oo_copy_file_owner(sock->file, priv->_filp);
+  if( rc != 0 ) {
+    efab_tcp_helper_destroy_os_sock(priv);
+    return rc;
   }
-  efrm_file_f_owner(sock->file)->signum =
-                               efrm_file_f_owner(priv->_filp)->signum;
 
   rc = ci_tcp_sync_sockopts_to_os_sock(ni, ep->id, sock);
   put_linux_socket(sock);

--- a/src/lib/efthrm/tcp_helper_endpoint_move.c
+++ b/src/lib/efthrm/tcp_helper_endpoint_move.c
@@ -416,12 +416,10 @@ int efab_file_move_to_alien_stack(ci_private_t *priv, ci_netif *alien_ni,
   new_ep->file_ptr = priv->_filp;
 
   /* Copy F_SETOWN_EX, F_SETSIG to the new file */
-#ifdef F_SETOWN_EX
   rcu_read_lock();
   __f_setown(old_ep->alien_ref->_filp, efrm_file_f_owner(priv->_filp)->pid,
              efrm_file_f_owner(priv->_filp)->pid_type, 1);
   rcu_read_unlock();
-#endif
   efrm_file_f_owner(old_ep->alien_ref->_filp)->signum =
                                       efrm_file_f_owner(priv->_filp)->signum;
   old_ep->alien_ref->_filp->f_flags |= priv->_filp->f_flags & O_NONBLOCK;

--- a/src/lib/efthrm/tcp_helper_endpoint_move.c
+++ b/src/lib/efthrm/tcp_helper_endpoint_move.c
@@ -416,12 +416,10 @@ int efab_file_move_to_alien_stack(ci_private_t *priv, ci_netif *alien_ni,
   new_ep->file_ptr = priv->_filp;
 
   /* Copy F_SETOWN_EX, F_SETSIG to the new file */
-  rcu_read_lock();
-  __f_setown(old_ep->alien_ref->_filp, efrm_file_f_owner(priv->_filp)->pid,
-             efrm_file_f_owner(priv->_filp)->pid_type, 1);
-  rcu_read_unlock();
-  efrm_file_f_owner(old_ep->alien_ref->_filp)->signum =
-                                      efrm_file_f_owner(priv->_filp)->signum;
+  rc = oo_copy_file_owner(old_ep->alien_ref->_filp, priv->_filp);
+  if( rc != 0 )
+    goto fail5;
+
   old_ep->alien_ref->_filp->f_flags |= priv->_filp->f_flags & O_NONBLOCK;
 
   /********* Point of no return  **********/
@@ -544,6 +542,8 @@ int efab_file_move_to_alien_stack(ci_private_t *priv, ci_netif *alien_ni,
                        ci_tcp_state_str(new_s->b.state)));
   return 0;
 
+fail5:
+  fput(old_ep->alien_ref->_filp);
 fail4:
   /* We clear the filters from the new ep.
    * For now, we do not need to re-insert old filters because hw filters


### PR DESCRIPTION
Using Onload with Linux-6.12 results in crash with NULL pointer dereference.  It happens in many tests in Socket Tester, in nginx, in other cases.  In the git log I see that linux-6.12 support was added under ON-16108, but it definitely was not tested properly.

With these patches I see some basic tests passing on Linux-6.12.