### PR TITLE
Fix driver build for linux 6.13

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -118,7 +118,7 @@ AUTOCOMPAT := $(obj)/src/driver/linux_resource/autocompat.h
 LINUX_RESOURCE := $(src)/src/driver/linux_resource
 $(AUTOCOMPAT): $(LINUX_RESOURCE)/kernel_compat.sh $(LINUX_RESOURCE)/kernel_compat_funcs.sh
 	@mkdir -p $(@D)
-	($< -k $(CURDIR) $(if $(filter 1,$(V)),-v,-q) > $@) || (rm -f $@ && false)
+	($< -k $(realpath $(objtree)) $(if $(filter 1,$(V)),-v,-q) > $@) || (rm -f $@ && false)
 
 mkdirs:
 	@mkdir -p $(obj)/src/lib/efhw
@@ -251,7 +251,7 @@ $(scripts): $(KBUILDTOP)/driver/linux/%.sh: src/driver/linux/%.sh
 
 modules modules_install: $(OUTMAKEFILES)
 	$(Q)$(MAKE) -C $(KPATH) M=$(KBUILDTOP) \
-		"src=\$$(patsubst $(KBUILDTOP)%,$$PWD%,\$$(obj))" \
+		"src=\$$(patsubst $(KBUILDTOP)%,$$PWD%,\$$(realpath \$$(obj)))" \
 		"SRCPATH=$$PWD/src" \
 		'subdir-ccflags-y=$(subst ','\'',$(ONLOAD_CFLAGS))' \
 		MMAKE_IN_KBUILD=1 MMAKE_USE_KBUILD=1 MMAKE_NO_RULES=1 \

--- a/src/driver/linux_onload/onloadfs.c
+++ b/src/driver/linux_onload/onloadfs.c
@@ -346,7 +346,7 @@ oo_create_fd(tcp_helper_resource_t* thr, oo_sp ep_id, int flags,
 
   if( _filp && *_filp ) {
     rcu_read_lock();
-    rc = get_file_rcu(*_filp);
+    rc = !IS_ERR_OR_NULL(ci_get_file_rcu(_filp));
     rcu_read_unlock();
     if( rc == 0 ) {
       OO_DEBUG_TCPH(ci_log("%s: fd=%d reuses file", __FUNCTION__, fd));

--- a/src/driver/linux_resource/kernel_compat.sh
+++ b/src/driver/linux_resource/kernel_compat.sh
@@ -177,6 +177,7 @@ EFRM_HAVE_FOLLOW_PTE symbol follow_pte include/linux/mm.h
 EFRM_HAVE_FOLLOW_PTE_VMA symtype follow_pte include/linux/mm.h int(struct vm_area_struct*, unsigned long, pte_t**, spinlock_t**)
 
 EFRM_HAVE_LINUX_TPH_H 			file	include/linux/pci-tph.h
+EFRM_HAVE_GET_FILE_RCU_FUNC symtype get_file_rcu include/linux/fs.h struct file*(struct file __rcu **)
 
 # TODO move onload-related stuff from net kernel_compat
 " | grep -E -v -e '^#' -e '^$' | sed 's/[ \t][ \t]*/:/g'

--- a/src/lib/efthrm/tcp_helper_ioctl.c
+++ b/src/lib/efthrm/tcp_helper_ioctl.c
@@ -340,7 +340,7 @@ efab_tcp_helper_detach_file(tcp_helper_endpoint_t* ep,
   filp = ep->file_ptr;
   /* filp might be NULL if we raced with FD close, other than that
    * filp is still valid even if close completed concurrently thanks to rcu_lock */
-  if( filp == NULL || ! get_file_rcu(filp) ) {
+  if( filp == NULL || IS_ERR_OR_NULL(ci_get_file_rcu(&filp)) ) {
     /* filp is being freed concurrently, best to back off until it is completed */
     OO_DEBUG_TCPH(ci_log("%s: pid=%d fd=%d => is being freed", __FUNCTION__, pid, fd));
     CITP_STATS_NETIF_INC(&trs->netif, sock_attach_fd_detach_fail_soft);

--- a/src/lib/efthrm/tcp_helper_linux.c
+++ b/src/lib/efthrm/tcp_helper_linux.c
@@ -414,7 +414,7 @@ static unsigned efab_linux_tcp_helper_fop_poll_tcp(struct file* filp,
   efab_fop_poll__prime_if_needed(trs, tep_p,
                                  SOCK_POLL_AWAITING_EVENTS(mask, wait),
                                  enable_interrupts);
-  if( ! poll_does_not_wait(wait) && s->b.state == CI_TCP_CLOSED &&
+  if( wait && wait->_qproc && s->b.state == CI_TCP_CLOSED &&
       tep_p->os_socket  != NULL) {
     /* From the closed state, handover is possible.  We should add OS
      * socket waitqueue to the poll table.


### PR DESCRIPTION
Fix issue #264 and couple of others related to linux-6.13.

---

Checked by running `HAVE_SFC=0 make` on a few kernels: 5.15, 6.1, 6.13.
Build and some basic tests pass. 