### PR TITLE
TPH mode in ef10 isn't ever enabled.

### DIFF
--- a/src/include/ci/efhw/tph.h
+++ b/src/include/ci/efhw/tph.h
@@ -1,6 +1,8 @@
 /* SPDX-License-Identifier: GPL-2.0 OR BSD-2-Clause */
 /* X-SPDX-Copyright-Text: Copyright (C) 2024, Advanced Micro Devices, Inc. */
 
+#include <ci/driver/kernel_compat.h>
+
 #ifdef EFRM_HAVE_LINUX_TPH_H
 #include <linux/pci-tph.h>
 #else


### PR DESCRIPTION
This is due to the compatibility version of `pcie_tph_get_cpu_st()` always being used (`EFRM_HAVE_LINUX_TPH_H` isn't defined before including `ci/efhw/tph.h`).

Here's a one line change to include `ci/driver/kernel_compat.h` in the same fashion as in `ef10ct.c`, though maybe it's better for `ci/efhw/tph.h` to include it?

Testing: enabling steering on X2522 no longer reports EINVAL.

Regards
