### PR TITLE
Fix --kernelver=<VER> in onload_build.

### DIFF
--- a/scripts/onload_build
+++ b/scripts/onload_build
@@ -69,7 +69,7 @@ parallel=-j$(nproc 2> /dev/null || echo 4)
 while [ $# -gt 0 ]; do
   case "$1" in
   --kernelver)  [ $# -gt 1 ] || usage; KVER="$2"; export KVER; shift;;
-  --kernelver=*)KVER=${1#--kernelver=};;
+  --kernelver=*)KVER=${1#--kernelver=}; export KVER;;
   --user)       all=false; user=true;;
   --user32)     err "No 32-bit build support"; exit 2;;
   --user64)     all=false; user64=true;;


### PR DESCRIPTION
It's missing an `export KVER` compared with the `--kernelver <VER>` path.

Before:

```sh
> uname -r
6.14.3-300.fc42.x86_64

> ./scripts/onload_build --kernel --user64 --kernelver=6.14.5-300.fc42.x86_64
...
> ll build
total 0
drwxr-x--- 1 luke luke 222 May  9 19:38 gnu_x86_64
drwxr-x--- 1 luke luke 292 May  9 19:38 x86_64_linux-6.14.3-300.fc42.x86_64
```

After:

```sh
> ./scripts/onload_build --kernel --user64 --kernelver=6.14.5-300.fc42.x86_64
...
> ll build
total 0
drwxr-x--- 1 luke luke 222 May  9 19:40 gnu_x86_64
drwxr-x--- 1 luke luke 292 May  9 19:40 x86_64_linux-6.14.5-300.fc42.x86_64
```

Thanks