### PR TITLE
Do not allow hw filter stealing in no-5tuple support scenarios

### DIFF
--- a/src/lib/efthrm/oof_filters.c
+++ b/src/lib/efthrm/oof_filters.c
@@ -2548,14 +2548,23 @@ oof_socket_add_wild(struct oof_manager* fm, struct oof_socket* skf,
   else if( ! oof_socket_can_share_hw_filter(skf, &lpa->lpa_filter) ) {
     /* H/w filter already exists but points to a different stack.  This is
      * fixed if necessary in oof_local_port_addr_fixup_wild().
+     *
+     * oof_local_port_addr_fixup_wild will not fix the hw filters if
+     * (!oof_socket_can_share_hw_filter && fm->fm_hwports_no5tuple). This will
+     * result in this stack reusing a hw filter that points to a different
+     * stack, resulting in unaccelerated sockets in this stack. Return an error
+     * here to prevent this.
      */
-    OO_DEBUG_IPF(other_skf = oof_wild_socket(lp, lpa, skf->af_space);
-                 if( other_skf != NULL )
-                   ci_log(FSK_FMT "STEAL "IPX_TRIPLE_FMT" from "SK_FMT,
-                          FSK_PRI_ARGS(skf),
-                          IPX_TRIPLE_ARGS(lp->lp_protocol,
-                          AF_IP(laddr), lp->lp_lport),
-                          SK_PRI_ARGS(other_skf)));
+    if( fm->fm_hwports_no5tuple )
+      rc = -EEXIST;
+    else
+      OO_DEBUG_IPF(other_skf = oof_wild_socket(lp, lpa, skf->af_space);
+                   if( other_skf != NULL )
+                     ci_log(FSK_FMT "STEAL "IPX_TRIPLE_FMT" from "SK_FMT,
+                            FSK_PRI_ARGS(skf),
+                            IPX_TRIPLE_ARGS(lp->lp_protocol,
+                            AF_IP(laddr), lp->lp_lport),
+                            SK_PRI_ARGS(other_skf)));
   }
   if( nat_preimage.n_results > 0 )
     oof_nat_table_lookup_free(&nat_preimage);

--- a/src/lib/efthrm/oof_filters.c
+++ b/src/lib/efthrm/oof_filters.c
@@ -2555,16 +2555,18 @@ oof_socket_add_wild(struct oof_manager* fm, struct oof_socket* skf,
      * stack, resulting in unaccelerated sockets in this stack. Return an error
      * here to prevent this.
      */
-    if( fm->fm_hwports_no5tuple )
+    if( fm->fm_hwports_no5tuple ) {
       rc = -EEXIST;
-    else
+    }
+    else {
       OO_DEBUG_IPF(other_skf = oof_wild_socket(lp, lpa, skf->af_space);
-                   if( other_skf != NULL )
-                     ci_log(FSK_FMT "STEAL "IPX_TRIPLE_FMT" from "SK_FMT,
-                            FSK_PRI_ARGS(skf),
-                            IPX_TRIPLE_ARGS(lp->lp_protocol,
-                            AF_IP(laddr), lp->lp_lport),
-                            SK_PRI_ARGS(other_skf)));
+      if( other_skf != NULL )
+        ci_log(FSK_FMT "STEAL "IPX_TRIPLE_FMT" from "SK_FMT,
+                   FSK_PRI_ARGS(skf),
+                   IPX_TRIPLE_ARGS(lp->lp_protocol,
+                   AF_IP(laddr), lp->lp_lport),
+                   SK_PRI_ARGS(other_skf)));
+    }
   }
   if( nat_preimage.n_results > 0 )
     oof_nat_table_lookup_free(&nat_preimage);


### PR DESCRIPTION
Currently we're running into the following behavior in AF_XDP based deployment (which is 3-tuple only support):

- Onload stack A starts and listens on port X.
- Onload stack A exits; its cleanup of hw filters is delayed.
- Onload stack B starts and listens on the same port X.
- Onload stack B sees the 3-tuple hw filter inserted by stack A, which has not yet been cleaned.
- In the current code, stack B will reuse the hw filter of stack A, but that 3-tuple hw filter points to the wrong stack, and the wrong RX queue.
- This causes all the sockets created by stack B to become unaccelerated, because they land on the rxq that belonged to stack A, not the rxq that belongs to stack B.

The root cause of this issue is that oof_socket_add_wild expects oof_local_port_addr_fixup_wild to fix hw filters that point to different stacks, but that will not actually happen if
(!oof_socket_can_share_hw_filter && fm->fm_hwports_no5tuple). This creates the undesirable behavior that all sockets in this new stack being unaccelerated, even when the user passed EF_NO_FAIL=0 (!)

Fix this by returning an error in this edge case. This means that a new onload stack will not reuse a hw filter that doesn't belong to it. The user can restart the workload when the old onload stack has finished cleanup of hw filters.

Note that this patch will change the behavior for all fm->fm_hwports_no5tuple deployments. This seems beneficial as all those deployments should see the same bug, but other options are possible:
- We could add a module parameter that configures this behavior.
- We may be able to only disable this behavior for AF_XDP deployments.

tested by running these commands with onload in a tight loop:

onload tcp_rr -F 1000
onload udp_rr -F 1000

tcp_rr and udp_rr reuse the same ports by default. In all cases, onload will start successfully if there is no existing hw filter left over from the previous onload invocation, and will fail with -EEXIST if there is a left over filter from the previous stack.

Change-Id: I6e196ac55cc81efbc537206cdc6e20b2068a7e3d