### PR TITLE
Improve select iterate speed

### DIFF
--- a/src/lib/transport/unix/poll_select.c
+++ b/src/lib/transport/unix/poll_select.c
@@ -155,7 +155,7 @@ static inline int do_sys_select(const char* why, int nfds,
  * get next fd bit.
  * /
 
-static inline ci_fd_mask ci_bitmap_next_set(ci_fd_mask *ai, ci_fd_mask i, int nwords)
+ci_inline ci_fd_mask ci_bitmap_next_set(ci_fd_mask *ai, ci_fd_mask i, int nwords)
 {
   ci_fd_mask i0 = i / CI_NFDBITS;
   ci_fd_mask i1 = i % CI_NFDBITS;


### PR DESCRIPTION
Traverse a bitmap in an alternative way
It performs particularly well in scenarios where file descriptors are sparsely distributed.

The larger the FD value, the better the performance.
such as:
(if fd is 1000)
fd_set readfds;
FD_ZERO(&readfds);
FD_SET(1000, &readfds);
select(1000 + 1, &readfds, NULL, NULL, NULL);

select achieves a performance boost of over 20x when handling large file descriptor.