### PR TITLE
tcp_filters: Remove filter when efrm_filter_redirect fails

### DIFF
--- a/src/lib/efthrm/tcp_filters.c
+++ b/src/lib/efthrm/tcp_filters.c
@@ -276,7 +276,11 @@ oo_hw_filter_set_hwport(struct oo_hw_filter* oofilter, int hwport,
          *  * does not know about our filter, let's better
          *    remove reference to it and try to add new instance
          *  * does not support move the move operation - we cannot leak the filter
+         *
+         * As a precaution, remove the filter, because some netdevs refuse to
+         * re-insert a duplicate filter.
          */
+        efrm_filter_remove(get_client(hwport), oofilter->filter_id[hwport]);
         oofilter->filter_id[hwport] = rc;
       }
       else {


### PR DESCRIPTION
When efrm_filter_redirect fails with ENOENT or ENODEV, the code path would reach efrm_filter_insert, which would try to insert a filter rule with the same filter but different flow steering target queue.

In the case of AF_XDP, efrm_filter_redirect is not implemented (always ENODEV), and some netdevs return an error for af_xdp_filter_insert (via set_rxnfc) when it detects duplicate flow steering rules, even if the target queue is different, requiring the caller to remove the prior filter first. This patch addresses this.

Without the patch, if filter_insert errors, oofilter->filter_id[hwport] is left as the error code from efrm_filter_redirect and the old rule is forgotten by onload and left dangling.