### PR TITLE
Do not handle wakeup events if the event queue is not primed

### DIFF
--- a/src/lib/efthrm/tcp_helper_resource.c
+++ b/src/lib/efthrm/tcp_helper_resource.c
@@ -6444,13 +6444,22 @@ static int tcp_helper_wakeup(tcp_helper_resource_t* trs, int intf_i, int budget)
 {
   ci_netif* ni = &trs->netif;
   int n = 0, prime_async;
+  struct efhw_nic *nic;
+  bool primed;
 
   TCP_HELPER_RESOURCE_ASSERT_VALID(trs, -1);
   OO_DEBUG_RES(ci_log(FN_FMT, FN_PRI_ARGS(ni)));
   CITP_STATS_NETIF_INC(ni, interrupts);
 
   /* Must clear this before the poll rather than waiting till later */
-  ci_bit_clear(&ni->state->evq_primed, intf_i);
+  primed = ci_bit_test_and_clear(&ni->state->evq_primed, intf_i);
+
+  /* Do not handle events if we were not primed when using AF_XDP. With AF_XDP
+   * we get spurious wakeups everytime the socket is ready as we add a waiter to
+   * socket waitqueue in af_xdp_init and only remove it in xdp_release_vi. */
+  nic = efrm_client_get_nic(trs->nic[intf_i].thn_oo_nic->efrm_client);
+  if (nic && nic->devtype.arch == EFHW_ARCH_AF_XDP && !primed)
+    return 0;
 
   if( budget <= 0 ) {
     defer_poll_and_prime(trs);


### PR DESCRIPTION
Onload stack in kernel for AF_XDP unnecessarlyy tries to handle events even when the event queue is not primed. This wastes cpu cycles and also introduces lock contention when we are running in spinning mode.

Return early and do not handle wakeup events if the event qeueue was not primed when using AF_XDP.

Latency before this change:
latency_p50=0.000015350
latency_p90=0.000021750
latency_p99=0.000023030
latency_p99.9=0.000024630

Latency after this change:
latency_p50=0.000014230
latency_p90=0.000014550
latency_p99=0.000015990
latency_p99.9=0.000017430