### PR TITLE
Ensure fdtable seq is assigned atomically

### DIFF
--- a/src/lib/transport/unix/internal.h
+++ b/src/lib/transport/unix/internal.h
@@ -334,7 +334,7 @@ ci_inline void citp_fdinfo_init(citp_fdinfo* fdi, citp_protocol_impl* p) {
   fdi->can_cache = 0;
 #endif
   fdi->protocol = p;
-  fdi->seq = fdtable_seq_no++;
+  fdi->seq = __sync_fetch_and_add(&fdtable_seq_no, 1);
   fdi->epoll_fd = -1;
   fdi->thread_id = PTHREAD_NULL;
 }


### PR DESCRIPTION
When two threads concurrently invoke the socket function, the absence of
lock protection in citp_fdinfo_init may occasionally result in identical
sequence numbers (seq) being assigned to different fdi entries. 

This change replaces the non-atomic increment with __sync_fetch_and_add
to guarantee uniqueness of seq in a multi-threaded environment.