### PR TITLE
Add select discrete mode

### DIFF
--- a/src/include/ci/internal/opts_citp_def.h
+++ b/src/include/ci/internal/opts_citp_def.h
@@ -61,6 +61,18 @@ CI_CFG_OPT("EF_SELECT_FAST", ul_select_fast, ci_uint32,
 "practice a vast majority of applications work fine with this option.",
            1, , 1, 0, 1, yesno)
 
+CI_CFG_OPT("EF_SELECT_DISCRETE_MODE", ul_select_discrete_mode, ci_uint32,
+"When the smallest file descriptor in the fd_set passed to select is relatively "
+"large, the file descriptors are non-contiguous, and the number of file "
+"descriptors in the fd_set is small, this pattern delivers significantly "
+"improved performance."
+"Under these conditions, the invocation latency of the select interface can be "
+"reduced by up to several tens of times compared to previous modes.\n"
+
+"However, this performance enhancement pattern is applicable only under "
+"specific scenarios and requires users to enable it based on actual conditions.",
+           1, , 0, 0, 1, yesno)
+	
 CI_CFG_OPT("EF_UL_POLL", ul_poll, ci_uint32,
 "Clear to disable acceleration of poll() calls at user-level.",
            1, , 1, 0, 1, yesno)

--- a/src/lib/transport/unix/poll_select.c
+++ b/src/lib/transport/unix/poll_select.c
@@ -28,6 +28,7 @@ do {                                                    \
   }                                                     \
 } while(0)
 
+#define ci_count_trailing_zeros(x) __builtin_ctzll(x)
 
 static void select_zero(fd_set* rds, fd_set* wrs, fd_set* exs, int n_words)
 {
@@ -150,6 +151,33 @@ static inline int do_sys_select(const char* why, int nfds,
 #endif
 
 /*
+ * get next fd bit.
+ */
+ci_inline ci_fd_mask ci_bitmap_next_set(ci_fd_mask *ai, ci_fd_mask i, int nwords)
+{
+  ci_fd_mask i0 = i / CI_NFDBITS;
+  ci_fd_mask i1 = i % CI_NFDBITS;
+  ci_fd_mask t;
+
+  if (i0 < nwords) {
+    t = (ai[i0] >> i1) << i1;
+
+    if (t) {
+      return ci_count_trailing_zeros(t) + i0 * CI_NFDBITS;
+    }
+
+    for (i0++; i0 < nwords; i0++) {
+      t = ai[i0];
+      if (t) {
+        return ci_count_trailing_zeros(t) + i0 * CI_NFDBITS;
+      }
+    }
+  }
+
+  return ~0;
+}
+
+/*
 ** Performs a select for user level entries in the fdset
 ** Input fdsets are {rd,wr,ex}in
 ** Kernel fds are returned in {rd,rw,ex}k - assumed clear on entry
@@ -170,35 +198,89 @@ ci_inline int citp_ul_select(struct oo_ul_select_state*__restrict__ s)
 
   s->is_kernel_fd = 0;
 
-  for( fd = 0; fd < s->nfds_inited; ++fd ) {
-    r = FD_ISSET(fd, s->rdi);
-    w = FD_ISSET(fd, s->wri);
-    e = FD_ISSET(fd, s->exi);
+  if (CITP_OPTS.ul_select_discrete_mode) {
+    int n_words, i, fd_min = -1;
+    n_words = (s->nfds_inited + CI_NFDBITS - 1) / CI_NFDBITS;
+    ci_fd_mask union_fds[n_words];
+    ci_fd_mask *rdm = (ci_fd_mask*)s->rdi;
+    ci_fd_mask *wrm = (ci_fd_mask*)s->wri;
+    ci_fd_mask *exm = (ci_fd_mask*)s->exi;
+    ci_fd_mask rdvalue, wrvalue, exvalue;
 
-    if( r | w | e ) {
-      citp_fdinfo_p fdip = citp_fdtable.table[fd].fdip;
-      if( fdip_is_normal(fdip) ) {
-	citp_fdinfo* fdi = fdip_to_fdi(fdip);
+    for( i = 0; i < n_words; i++ ) {
+      rdvalue = rdm ? rdm[i] : 0;
+      wrvalue = wrm ? wrm[i] : 0;
+      exvalue = exm ? exm[i] : 0;
 
-        /* If SO_BUSY_POLL behaviour requested need to check if there is
-         * a spinning socket in the set, and remove flag to enable spinning
-         * if it is found */
-        if( ( s->ul_select_spin & (1 << ONLOAD_SPIN_SO_BUSY_POLL) ) &&
-            citp_fdinfo_get_ops(fdip_to_fdi(fdip))->
-                                        is_spinning(fdip_to_fdi(fdip)) ) {
-          s->ul_select_spin &= ~(1 << ONLOAD_SPIN_SO_BUSY_POLL);
+      union_fds[i] = rdvalue | wrvalue | exvalue;
+      if (union_fds[i] != 0 && fd_min == -1) {
+        fd_min = i * CI_NFDBITS + ci_count_trailing_zeros(union_fds[i]);
+      }
+    }
+
+    for( fd = fd_min; fd < s->nfds_inited && fd != ~0;
+        fd = ci_bitmap_next_set( union_fds, fd + 1, n_words ) ) {
+      r = FD_ISSET(fd, s->rdi);
+      w = FD_ISSET(fd, s->wri);
+      e = FD_ISSET(fd, s->exi);
+
+      if( r | w | e ) {
+        citp_fdinfo_p fdip = citp_fdtable.table[fd].fdip;
+        if( fdip_is_normal(fdip) ) {
+          citp_fdinfo* fdi = fdip_to_fdi(fdip);
+
+          /* If SO_BUSY_POLL behaviour requested need to check if there is
+           * a spinning socket in the set, and remove flag to enable spinning
+           * if it is found */
+          if( ( s->ul_select_spin & (1 << ONLOAD_SPIN_SO_BUSY_POLL) ) &&
+            citp_fdinfo_get_ops(fdip_to_fdi(fdip))->is_spinning(fdip_to_fdi(fdip)) ) {
+            s->ul_select_spin &= ~(1 << ONLOAD_SPIN_SO_BUSY_POLL);
+          }
+
+          if( citp_fdinfo_get_ops(fdi)->select(fdi, &n, r, w, e, s) ) {
+            s->is_ul_fd = 1;
+            continue;
+          }
         }
 
-	if( citp_fdinfo_get_ops(fdi)->select(fdi, &n, r, w, e, s) ) {
-	  s->is_ul_fd = 1;
-	  continue;
-	}
+        if( r )  FD_SET(fd, s->rdk);
+        if( w )  FD_SET(fd, s->wrk);
+        if( e )  FD_SET(fd, s->exk);
+        s->is_kernel_fd = 1;
       }
+    }
 
-      if( r )  FD_SET(fd, s->rdk);
-      if( w )  FD_SET(fd, s->wrk);
-      if( e )  FD_SET(fd, s->exk);
-      s->is_kernel_fd = 1;
+    fd = s->nfds_inited;
+  } else {
+    for( fd = 0; fd < s->nfds_inited; ++fd ) {
+      r = FD_ISSET(fd, s->rdi);
+      w = FD_ISSET(fd, s->wri);
+      e = FD_ISSET(fd, s->exi);
+
+      if( r | w | e ) {
+        citp_fdinfo_p fdip = citp_fdtable.table[fd].fdip;
+        if( fdip_is_normal(fdip) ) {
+          citp_fdinfo* fdi = fdip_to_fdi(fdip);
+
+          /* If SO_BUSY_POLL behaviour requested need to check if there is
+          * a spinning socket in the set, and remove flag to enable spinning
+          * if it is found */
+          if( ( s->ul_select_spin & (1 << ONLOAD_SPIN_SO_BUSY_POLL) ) &&
+            citp_fdinfo_get_ops(fdip_to_fdi(fdip))->is_spinning(fdip_to_fdi(fdip)) ) {
+            s->ul_select_spin &= ~(1 << ONLOAD_SPIN_SO_BUSY_POLL);
+          }
+
+          if( citp_fdinfo_get_ops(fdi)->select(fdi, &n, r, w, e, s) ) {
+            s->is_ul_fd = 1;
+            continue;
+          }
+        }
+
+        if( r )  FD_SET(fd, s->rdk);
+        if( w )  FD_SET(fd, s->wrk);
+        if( e )  FD_SET(fd, s->exk);
+        s->is_kernel_fd = 1;
+      }
     }
   }
 


### PR DESCRIPTION
Add a Discrete Mode to select.‌ 

This mode is designed to optimize scenarios where ‌file descriptors (fds) are scattered‌ and the ‌smallest fd within the fdset is relatively large‌. 
In such cases, it locates the smallest ‌user-defined fd‌ in the fastest possible manner, ‌instead of iterating from 0‌. 
For loops can sometimes become a ‌significant performance bottleneck‌, especially in ‌non-blocking mode‌ with select. 
While this mode ‌does not guarantee performance gains universally‌, it provides substantial improvement when the smallest user-defined fd is low (e.g., 32). 
If the smallest fd is 1000, citp_ul_select ‌executes over 20 times faster‌ compared to the conventional iterative approach.

such as:
        (user call open open open open ......)
        fd = socket(AF_INET, SOCK_STREAM, 0); 
        
        //then fd is 64. 

        FD_ZERO(&readfds);
        FD_SET(fd, &readfds);
        max_sd = fd;
        
        struct timeval timeout;
        timeout.tv_sec = 0;
        timeout.tv_usec = 0;

        activity = select(max_sd + 1, &readfds, NULL, NULL, &timeout);

The citp_ul_select function requires only two iterations to retrieve the user-configured value of fd 64.