### PR TITLE
Alternative to legacy distutils

### DIFF
--- a/scripts/onload_misc/setup.py
+++ b/scripts/onload_misc/setup.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: GPL-2.0
 # X-SPDX-Copyright-Text: (c) Copyright 2011-2019 Xilinx, Inc.
-from distutils.core import setup
+from setuptools import setup
 setup(name='OpenOnload utilities',
       version='1.0',
       author='David Riddoch',


### PR DESCRIPTION
distutils was deprecated in Python 3.10 and fully removed in Python 3.12

Systems like rhel 10 install Python 3.12

This change replaces distutils with setuptools
