### PR TITLE
Fix compatibility with Linux kernel 6.15–6.16 ABI/API changes

### DIFF
--- a/src/driver/linux_net/drivers/net/ethernet/sfc/kernel_compat.sh
+++ b/src/driver/linux_net/drivers/net/ethernet/sfc/kernel_compat.sh
@@ -290,6 +290,7 @@ EFX_HAVE_NET_RPS_H                     file       include/net/rps.h
 EFX_HAVE_IP_TUNNEL_FLAGS_TO_BE16	symbol	ip_tunnel_flags_to_be16	include/net/ip_tunnels.h
 EFX_NEED_TIME64_TO_TM			nsymbol	time64_to_tm		include/linux/time.h
 EFX_HAVE_ASSIGN_STR_NO_SRC_ARG      custom
+EFX_HAVE_TRY_LOOKUP_NOPERM		symbol	try_lookup_noperm	include/linux/namei.h
 " | grep -E -v -e '^#' -e '^$' | sed 's/[ \t][ \t]*/:/g'
 }
 

--- a/src/driver/linux_resource/kernel_compat.sh
+++ b/src/driver/linux_resource/kernel_compat.sh
@@ -47,7 +47,7 @@ EFRM_HAVE_ALLOC_FILE_PSEUDO		symbol	alloc_file_pseudo	include/linux/file.h
 EFRM_NET_HAS_PROC_INUM			member	struct_net proc_inum	include/net/net_namespace.h
 EFRM_NET_HAS_USER_NS			member	struct_net user_ns	include/net/net_namespace.h
 
-EFRM_HAVE_OLD_FAULT			memtype struct_vm_operations_struct	fault	include/linux/mm.h	int (*)(struct vm_area_struct *vma, struct vm_fault *vmf)
+EFRM_HAVE_OLD_FAULT			memtype struct_vm_operations_struct	fault	include/linux/mm.h	int (*)(struct vm_fault *vmf)
 EFRM_HAVE_NEW_FAULT			memtype struct_vm_operations_struct	fault	include/linux/mm.h	vm_fault_t (*)(struct vm_fault *vmf)
 
 EFRM_HAVE_SCHED_TASK_H			file	include/linux/sched/task.h
@@ -187,6 +187,9 @@ EFRM_HAVE_FOLLOW_PFNMAP_START symbol follow_pfnmap_start include/linux/mm.h
 
 EFRM_HAVE_FOLLOW_PTE symbol follow_pte include/linux/mm.h
 EFRM_HAVE_FOLLOW_PTE_VMA symtype follow_pte include/linux/mm.h int(struct vm_area_struct*, unsigned long, pte_t**, spinlock_t**)
+
+EFRM_PAGE_HAS_FOLIO_INDEX		member	struct_page	__folio_index	include/linux/mm_types.h
+EFRM_NEED_UNIXCB			nsymbol	UNIXCB	include/net/af_unix.h
 
 # TODO move onload-related stuff from net kernel_compat
 " | grep -E -v -e '^#' -e '^$' | sed 's/[ \t][ \t]*/:/g'

--- a/src/include/ci/tools/debug.h
+++ b/src/include/ci/tools/debug.h
@@ -47,7 +47,7 @@
 
 /* verifies compile time expression is 0 or positive -
  * no-op for runtime expressions */
-#if __GNUC__ * 100 + __GNUC_MINOR__ >= 409
+#if defined(__clang__) || __GNUC__ * 100 + __GNUC_MINOR__ >= 409
 #define CI_BUILD_ASSERT_CONSTANT_NON_NEGATIVE(c) \
   do {                                                              \
     char __CI_BUILD_ASSERT_NAME(__LINE__)                           \

--- a/src/lib/ciul/shrub_socket_kernel.c
+++ b/src/lib/ciul/shrub_socket_kernel.c
@@ -21,6 +21,21 @@
 #define ANCIENT_KERNEL_HACK
 #endif
 
+#ifdef EFRM_NEED_UNIXCB
+struct unix_skb_parms {
+	struct pid		*pid;		/* skb credentials	*/
+	kuid_t			uid;
+	kgid_t			gid;
+	struct scm_fp_list	*fp;		/* Passed files		*/
+#ifdef CONFIG_SECURITY_NETWORK
+	u32			secid;		/* Security ID		*/
+#endif
+	u32			consumed;
+} __randomize_layout;
+
+#define UNIXCB(skb)	(*(struct unix_skb_parms *)&((skb)->cb))
+#endif
+
 int ef_shrub_socket_open(uintptr_t* socket_out)
 {
   int rc;

--- a/src/lib/kernel_utils/hugetlb.c
+++ b/src/lib/kernel_utils/hugetlb.c
@@ -315,10 +315,15 @@ oo_hugetlb_page_offset(struct page *page)
 	 * for vanilla, and >= 5.14 for RHEL 9.6) where hugetlb_basepage_index()
 	 * was not present.
 	 */
-#if defined(EFRM_HAS_FILEMAP_LOCK_HUGETLB_FOLIO) && ! defined(EFRM_HAS_HUGETLB_BASEPAGE_INDEX)
-	return page->index * PAGE_SIZE;
+#ifdef EFRM_PAGE_HAS_FOLIO_INDEX
+	pgoff_t index = page->__folio_index;
 #else
-	return page->index * OO_HUGEPAGE_SIZE;
+	pgoff_t index = page->index;
+#endif
+#if defined(EFRM_HAS_FILEMAP_LOCK_HUGETLB_FOLIO) && ! defined(EFRM_HAS_HUGETLB_BASEPAGE_INDEX)
+	return index * PAGE_SIZE;
+#else
+	return index * OO_HUGEPAGE_SIZE;
 #endif
 }
 EXPORT_SYMBOL(oo_hugetlb_page_offset);


### PR DESCRIPTION
This patch is an extension of issue #293, addressing additional ABI/API changes required to successfully build against kernel 6.15+.

In addition to the `kbuild ccflags-y` issue reported in #293, this update resolves several compatibility problems introduced in recent upstream kernel changes:

- Renamed `page->index` to `page->__folio_index`  
  Upstream commit: [acc53a0](https://github.com/torvalds/linux/commit/acc53a0)

- `UNIXCB()` usage has been restricted to internal use  
  Upstream commit: [84960bf](https://github.com/torvalds/linux/commit/84960bf)

- Replaced `d_hash_and_lookup()` with `try_lookup_noperm()`  
  Upstream commit: [06c5674](https://github.com/torvalds/linux/commit/06c5674)

- Corrected `EFRM_HAVE_OLD_FAULT` usage: `vm_operations_struct::fault()` has consistently been a single-parameter function; `EFRM_HAVE_NEW_FAULT` remains valid  
  Upstream commit: [1c8f422](https://github.com/torvalds/linux/commit/1c8f422)

- Resolved Clang build error
  When building via `env LLVM=1 scripts/onload_build --kernelver <clang-compiled kernel>`, compilation would fail due to unsupported Clang extension:  
    `error: fields must have a constant size: variable length array in structure`
  The affected `#if` conditions have now been updated to use valid macros.


This patch introduces some new kernel_compact tests and can be merged independently. However, to fully build on Linux 6.15+, the `kbuild` adjustments from issue #293 are still required.

