### PR TITLE
cleanup: Use CI_CFG_PKT_BUF_SIZE instead of hardcoded number

### DIFF
--- a/src/include/onload/pkt_filler.h
+++ b/src/include/onload/pkt_filler.h
@@ -39,8 +39,8 @@ ci_inline void oo_pkt_filler_init(struct oo_pkt_filler* pf,
                                   ci_ip_pkt_fmt* pkt, void* buf_start) {
   pf->last_pkt = pf->pkt = pkt;
   pf->buf_start = buf_start;
-  /* ?? or could this just be ((char*) pkt + 2048) ? */
-  pf->buf_end = CI_PTR_ALIGN_FWD(PKT_START(pkt), 2048);
+  /* ?? or could this just be ((char*) pkt + CI_CFG_PKT_BUF_SIZE) ? */
+  pf->buf_end = CI_PTR_ALIGN_FWD(PKT_START(pkt), CI_CFG_PKT_BUF_SIZE);
   /* ?? FIXME: should depend on runtime buffer size */
 }
 

--- a/src/lib/ciul/efxdp_vi.c
+++ b/src/lib/ciul/efxdp_vi.c
@@ -17,6 +17,7 @@
 #ifdef HAVE_AF_XDP
 
 #include <linux/if_xdp.h>
+#include <ci/internal/transport_config_opt.h>
 #include "af_xdp_defs.h"
 #include "logging.h"
 
@@ -455,7 +456,7 @@ void efxdp_vi_init(ef_vi* vi)
                                  efxdp_ef_vi_transmitv_ctpio_fallback_not_supp;
   }
 
-  vi->rx_buffer_len = 2048;
+  vi->rx_buffer_len = CI_CFG_PKT_BUF_SIZE;
   vi->rx_prefix_len = 0;
   vi->evq_phase_bits = 1; /* We set this flag for ef_eventq_has_event */
 }


### PR DESCRIPTION
When trying to use onload with AF_XDP, changing CI_CFG_PKT_BUF_SIZE from 2048 to 4096 causes crashes, because some of the places in the code have 2048 hardcoded.

Switch to using CI_CFG_PKT_BUF_SIZE in all the harcoded places, fixes these crashes.