### PR TITLE
onload_remote_monitor: add creation time fields to ORM JSON output

### DIFF
--- a/src/tests/onload/onload_remote_monitor/internal_tests/test_ftl.c
+++ b/src/tests/onload/onload_remote_monitor/internal_tests/test_ftl.c
@@ -70,6 +70,9 @@ int main(int argc, char* argv[])
 #define FTL_TFIELD_INT(ctx, type, field_name, flag)        \
   CI_BUILD_ASSERT2( TYPE_TEST(v.field_name, type) );
 
+#define FTL_TFIELD_EXPR(ctx, type, field_name, expr, flag) \
+  CI_BUILD_ASSERT2(sizeof(type) > 0);
+
 /* check for static string.
  * The second check might give false positive if static char array is actually defined
  * to be the size of a pointer */

--- a/src/tools/onload_remote_monitor/ftl_defs.h
+++ b/src/tools/onload_remote_monitor/ftl_defs.h
@@ -470,6 +470,9 @@ typedef struct oo_p_dllink oo_p_dllink_t;
   FTL_TFIELD_INT(ctx, ci_int32, nic_n, ORM_OUTPUT_STACK)                  \
   FTL_TFIELD_INT(ctx, ci_uint64, evq_last_prime, ORM_OUTPUT_STACK)        \
   FTL_TFIELD_INT(ctx, ci_uint32, stack_id, ORM_OUTPUT_STACK)              \
+  FTL_TFIELD_INT(ctx, ci_uint32, creation_time_sec, ORM_OUTPUT_STACK)     \
+  FTL_TFIELD_EXPR(ctx, ci_uint32, creation_time_delta_sec,               \
+                  time(NULL) - stats->creation_time_sec, ORM_OUTPUT_STACK) \
   FTL_TFIELD_SSTR(ctx, pretty_name,  ORM_OUTPUT_STACK)                    \
   FTL_TFIELD_INT(ctx, ci_uint32, netif_mmap_bytes, ORM_OUTPUT_STACK)      \
   FTL_TFIELD_INT(ctx, ci_uint16, max_mss, ORM_OUTPUT_STACK)               \

--- a/src/tools/onload_remote_monitor/orm_json_lib.c
+++ b/src/tools/onload_remote_monitor/orm_json_lib.c
@@ -26,6 +26,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <ctype.h>
+#include <time.h>
 #include <errno.h>
 
 #include "../ip/sockbuf_filter.h"
@@ -628,6 +629,7 @@ static void orm_dump_struct_ci_netif_config_opts(char* label, ci_netif_config_op
 #undef FTL_TSTRUCT_BEGIN
 #undef FTL_TUNION_BEGIN
 #undef FTL_TFIELD_INT
+#undef FTL_TFIELD_EXPR
 #undef FTL_TFIELD_CONSTINT
 #undef FTL_TFIELD_STRUCT
 #undef FTL_TSTRUCT_END
@@ -664,6 +666,12 @@ static void orm_dump_struct_ci_netif_config_opts(char* label, ci_netif_config_op
   if (output_flags & display_flags) {                                   \
     dump_buf_literal("\"" #field_name "\":");                           \
     dump_buf_int_comma_##type(stats->field_name);                       \
+  }
+
+#define FTL_TFIELD_EXPR(ctx, type, field_name, expr, display_flags) \
+  if (output_flags & display_flags) {                                   \
+    dump_buf_literal("\"" #field_name "\":");                           \
+    dump_buf_cat_comma(type##_fmt, (type)(expr));                       \
   }
 
 #define FTL_TFIELD_CONSTINT(ctx, type, field_name, display_flags) \


### PR DESCRIPTION
## Summary
- Add `creation_time_sec` and computed `creation_time_delta_sec` to stack JSON output.
- Introduce `FTL_TFIELD_EXPR` handling in ORM JSON generation.
- Update internal test harness to define `FTL_TFIELD_EXPR`.

## Testing
- `PATH=".../scripts:$PATH" make -C build/gnu_x86_64/tests/onload/onload_remote_monitor/internal_tests test`
- `./scripts/run_unit_tests.sh`

## Notes
- No compatibility build needed; change is limited to user-space ORM JSON output and test harness macros.

## Example output

```
$ onload_stackdump dump | grep creat ; echo; orm_json |jq|grep creat
  creation_time=2025-12-19 19:03:23 (delta=43secs)

            "creation_time_sec": 1766171003,
            "creation_time_delta_sec": 43,
            "creation_numa_node": 0,
```
