### PR TITLE
orm_json: add optional stack pids via libstack mappings

### DIFF
--- a/src/tools/ip/libstack.h
+++ b/src/tools/ip/libstack.h
@@ -153,6 +153,8 @@ extern void sockets_watch(void);
 
 extern int /*rc*/ libstack_init(void);
 extern void libstack_stack_mapping_print(void);
+extern int libstack_stack_mapping_get_pids(int stack_id, const pid_t** pids,
+                                           int* n_pids);
 extern void libstack_pid_mapping_print(void);
 extern int libstack_env_print(void);
 extern int libstack_threads_print(void);
@@ -167,5 +169,4 @@ extern int libstack_netif_trylock(ci_netif* ni);
 
 
 #endif /* _CI_LIB_STACK_H */
-
 

--- a/src/tools/onload_remote_monitor/mmake.mk
+++ b/src/tools/onload_remote_monitor/mmake.mk
@@ -6,6 +6,7 @@ APPS := orm_json
 SRCS := orm_json orm_json_lib
 
 OBJS := $(patsubst %,%.o,$(SRCS))
+OBJS += $(TOPPATH)/src/tools/ip/libstack.o
 
 MMAKE_LIB_DEPS	:= $(CIIP_LIB_DEPEND) $(CIAPP_LIB_DEPEND) \
 		   $(CITOOLS_LIB_DEPEND) $(CIUL_LIB_DEPEND) \
@@ -41,7 +42,7 @@ all: $(APPS)
 orm_json: $(DEPS)
 	(libs="$(LIBS)"; $(MMakeLinkCApp))
 
-orm_zmq_publisher: orm_zmq_publisher.o orm_json_lib.o
+orm_zmq_publisher: orm_zmq_publisher.o orm_json_lib.o $(TOPPATH)/src/tools/ip/libstack.o
 	(libs="$(LIBS)"; $(MMakeLinkCApp))
 
 zmq_subscriber: zmq_subscriber.o

--- a/src/tools/onload_remote_monitor/orm_json.c
+++ b/src/tools/onload_remote_monitor/orm_json.c
@@ -60,8 +60,8 @@ int main(int argc, char** argv)
 
   ci_app_standard_opts = 0;
   ci_app_getopt(
-    "[stats] [more_stats] [tcp_stats] [stack] [stack_state] [vis] [opts] "
-    "[lots] [extra] [all]",
+    "[stats] [more_stats] [tcp_stats] [stack] [stack_state] [pids] [vis] "
+    "[opts] [lots] [extra] [all]",
     &argc, argv, cfg_opts, N_CFG_OPTS);
   ++argv;  --argc;
 

--- a/src/tools/onload_remote_monitor/orm_json_lib.c
+++ b/src/tools/onload_remote_monitor/orm_json_lib.c
@@ -28,6 +28,7 @@
 #include <ctype.h>
 #include <errno.h>
 
+#include "../ip/libstack.h"
 #include "../ip/sockbuf_filter.h"
 #include <ci/internal/more_stats.h>
 #include "orm_json_lib.h"
@@ -858,14 +859,48 @@ static void orm_waitable_dump(ci_netif* ni, const char* sock_type,
 }
 
 
-static int orm_shared_state_dump(ci_netif* ni, int output_flags,
+static int orm_stack_dump_pids(int stack_id)
+{
+  const pid_t* pids = NULL;
+  int n_pids = 0;
+  int i;
+  int rc;
+
+  rc = libstack_stack_mapping_get_pids(stack_id, &pids, &n_pids);
+  if( rc == -ENOENT ) {
+    LOG("Warning: No stack_mapping for stack %d found\n", stack_id);
+    n_pids = 0;
+    rc = 0;
+  }
+  else if( rc != 0 ) {
+    LOG("ERROR: Failed to get pids for stack %d (rc=%d)\n", stack_id, rc);
+    return rc;
+  }
+
+  dump_buf_literal("\"pids\":[");
+  for( i = 0; i < n_pids; ++i )
+    dump_buf_cat_comma("%d", (int) pids[i]);
+  dump_buf_cleanup();
+  dump_buf_literal_comma("]");
+  return 0;
+}
+
+
+static int orm_shared_state_dump(struct orm_stack* stack, int output_flags,
                                  const sockbuf_filter_t* sft)
 {
+  ci_netif* ni = &stack->os_ni;
   ci_netif_state* ns = ni->state;
+  int rc;
 
   dump_buf_literal("\"stack\":{");
   if( output_flags & ORM_OUTPUT_STACK )
     orm_dump_struct_ci_netif_state("stack_state", ns, output_flags);
+  if( output_flags & ORM_OUTPUT_PIDS ) {
+    rc = orm_stack_dump_pids(stack->os_id);
+    if( rc != 0 )
+      return rc;
+  }
   if( output_flags & ORM_OUTPUT_SOCKETS ) {
     orm_waitable_dump(ni, "tcp_listen", output_flags, sft);
     orm_waitable_dump(ni, "tcp", output_flags, sft);
@@ -909,10 +944,13 @@ static int orm_vis_dump(ci_netif* ni, int output_flags)
 /* Main */
 /**********************************************************/
 
-static int orm_netif_dump(ci_netif* ni, int id, int output_flags, bool cfg_flat,
-                          const char* stackname, const sockbuf_filter_t* sft)
+static int orm_netif_dump(struct orm_stack* stack, int output_flags,
+                          bool cfg_flat, const char* stackname,
+                          const sockbuf_filter_t* sft)
 {
   int rc;
+  ci_netif* ni = &stack->os_ni;
+  int id = stack->os_id;
 
   if (stackname != NULL)
     if ( strcmp(stackname, ni->state->name) != 0 )
@@ -951,8 +989,8 @@ static int orm_netif_dump(ci_netif* ni, int id, int output_flags, bool cfg_flat,
       return rc;
     }
   }
-  if (output_flags & (ORM_OUTPUT_STACK | ORM_OUTPUT_SOCKETS)) {
-    if( (rc = orm_shared_state_dump(ni, output_flags, sft)) != 0 ) {
+  if (output_flags & (ORM_OUTPUT_STACK | ORM_OUTPUT_SOCKETS | ORM_OUTPUT_PIDS)) {
+    if( (rc = orm_shared_state_dump(stack, output_flags, sft)) != 0 ) {
       LOG("stack error code %d\n",rc);
       return rc;
     }
@@ -1033,6 +1071,8 @@ int orm_parse_output_flags(int argc, const char* const* argv)
       output_flags |= ORM_OUTPUT_TCP_EXT_STATS_COUNT;
     else if ( !strcmp(argv[i], "stack_state") )
       output_flags |= ORM_OUTPUT_STACK;
+    else if ( !strcmp(argv[i], "pids") )
+      output_flags |= ORM_OUTPUT_PIDS;
     else if ( !strcmp(argv[i], "sockets") )
       output_flags |= ORM_OUTPUT_SOCKETS;
     else if ( !strcmp(argv[i], "stack") )
@@ -1046,7 +1086,7 @@ int orm_parse_output_flags(int argc, const char* const* argv)
     else if ( !strcmp(argv[i], "extra") )
       output_flags |= ORM_OUTPUT_EXTRA;
     else if ( !strcmp(argv[i], "all") )
-      output_flags |= ORM_OUTPUT_LOTS | ORM_OUTPUT_EXTRA;
+      output_flags |= ORM_OUTPUT_LOTS | ORM_OUTPUT_EXTRA | ORM_OUTPUT_PIDS;
     else
       valid = false;
   }
@@ -1174,10 +1214,8 @@ int orm_do_dump(const struct orm_cfg* cfg, int output_flags,
   if( cfg->flat )
     dump_buf_literal("\"stacks\":[");
   for( i = 0; i < state.n_stacks; ++i ) {
-    ci_netif* ni = &state.stacks[i]->os_ni;
-    int id       = state.stacks[i]->os_id;
-
-    if( (rc = orm_netif_dump(ni, id, output_flags, cfg->flat, cfg->stackname, &sft)) != 0 )
+    if( (rc = orm_netif_dump(state.stacks[i], output_flags, cfg->flat,
+                             cfg->stackname, &sft)) != 0 )
       goto done;
   }
 

--- a/src/tools/onload_remote_monitor/orm_json_lib.h
+++ b/src/tools/onload_remote_monitor/orm_json_lib.h
@@ -12,6 +12,7 @@
 #define ORM_OUTPUT_VIS 0x40
 #define ORM_OUTPUT_OPTS 0x100
 #define ORM_OUTPUT_EXTRA 0x100000
+#define ORM_OUTPUT_PIDS 0x200000
 #define ORM_OUTPUT_LOTS 0xFFFFF
 #define ORM_OUTPUT_SUM (ORM_OUTPUT_STATS | ORM_OUTPUT_MORE_STATS | \
                         ORM_OUTPUT_TCP_STATS_COUNT | \
@@ -35,4 +36,3 @@ extern int orm_parse_output_flags(int argc, const char* const* argv);
  */
 extern int orm_do_dump(const struct orm_cfg* cfg, int output_flags,
                        FILE* output_stream);
-

--- a/src/tools/onload_remote_monitor/orm_zmq_publisher.c
+++ b/src/tools/onload_remote_monitor/orm_zmq_publisher.c
@@ -40,8 +40,8 @@ int main(int argc, char** argv)
 {
   ci_app_standard_opts = 0;
   ci_app_getopt(
-    "[stats] [more_stats] [tcp_stats] [stack] [stack_state] [vis] [opts] "
-    "[lots] [extra] [all]",
+    "[stats] [more_stats] [tcp_stats] [stack] [stack_state] [pids] [vis] "
+    "[opts] [lots] [extra] [all]",
     &argc, argv, cfg_opts, N_CFG_OPTS);
   ++argv;  --argc;
 


### PR DESCRIPTION
### Summary
  - Add stack.pids as an opt-in field in orm_json/orm_zmq_publisher; it appears when using pids or all (default output remains unchanged).
  - Reuse libstack’s existing /proc mapping logic via libstack_stack_mapping_get_pids() to avoid duplication and keep stackdump/orm_json consistent.
  - Link libstack into the remote monitor tools to satisfy the new dependency.

### Tests

  - scripts/run_unit_tests.sh

### Exampke output

```
$ onload_stackdump
#stack-id stack-name      pids
1         -               11440

$ orm_json pids | jq -r '.json[] | to_entries[] | .value.stack.pids'
[
  11440
]

$ orm_json all | jq -r '.json[] | to_entries[] | .value.stack.pids'
[
  11440
]
```


