### PR TITLE
The onload-dkms package requires libcap-dev.

### DIFF
--- a/scripts/debian/debian-templ/control
+++ b/scripts/debian/debian-templ/control
@@ -26,7 +26,7 @@ Build-Profiles: <!pkg.#TYPE#.nosource>
 
 Package: #TYPE#-dkms
 Architecture: all
-Depends: dkms, #TYPE#-user (>= ${source:Version}), #TYPE#-user (<< ${source:Version}.1~), ${misc:Depends}
+Depends: dkms, libcap-dev, #TYPE#-user (>= ${source:Version}), #TYPE#-user (<< ${source:Version}.1~), ${misc:Depends}
 Description: Onload debian package with DKMS
 Conflicts: #TYPE#-modules
 Build-Profiles: <!pkg.#TYPE#.nodkms>


### PR DESCRIPTION
Hi

E.g. if installed in a minimal system that didn't generate the debs in the first place, the module build will fail.

I guess there's an argument to include more of the `Build-Depends` if requiring `dkms` (and `build-essential` transiently) doesn't bring in all the required deps, but I've not personally had a problem other than `libcap-dev`.

RPM looks OK due to `user_build_requires` for the akmod spec, AFAICT.

Thanks!
