### PR TITLE
-mtune=native was not being passed to the compiler on x86-64 as the default if MMAKE_CTUNE was not set.

### DIFF
--- a/mk/platform/gnu_x86_64.mk
+++ b/mk/platform/gnu_x86_64.mk
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: GPL-2.0 OR BSD-2-Clause
 # X-SPDX-Copyright-Text: (c) Copyright 2004-2020 Xilinx, Inc.
 GNU	    := 1
-MMAKE_CARCH ?= -mtune=native
+MMAKE_CTUNE ?= -mtune=native
 MMAKE_CARCH := -m64 $(MMAKE_CTUNE)
 
 MMAKE_RELOCATABLE_LIB := -z combreloc


### PR DESCRIPTION
Hello again

I assume this wasn't intended behaviour (also cf. the other arches), otherwise that `MMAKE_CARCH ?= -mtune=native` should presumably be removed?

Before: `... -m64   -Wall ...`
After: `... -m64 -mtune=native  -Wall ...`

Thanks
