### PR TITLE
ON-17300: do not put object file in source dir

### DIFF
--- a/src/tools/onload_remote_monitor/mmake.mk
+++ b/src/tools/onload_remote_monitor/mmake.mk
@@ -6,7 +6,7 @@ APPS := orm_json
 SRCS := orm_json orm_json_lib
 
 OBJS := $(patsubst %,%.o,$(SRCS))
-OBJS += $(TOPPATH)/src/tools/ip/libstack.o
+OBJS += $(BUILDPATH)/tools/ip/libstack.o
 
 MMAKE_LIB_DEPS	:= $(CIIP_LIB_DEPEND) $(CIAPP_LIB_DEPEND) \
 		   $(CITOOLS_LIB_DEPEND) $(CIUL_LIB_DEPEND) \
@@ -42,7 +42,7 @@ all: $(APPS)
 orm_json: $(DEPS)
 	(libs="$(LIBS)"; $(MMakeLinkCApp))
 
-orm_zmq_publisher: orm_zmq_publisher.o orm_json_lib.o $(TOPPATH)/src/tools/ip/libstack.o
+orm_zmq_publisher: orm_zmq_publisher.o orm_json_lib.o $(BUILDPATH)/tools/ip/libstack.o
 	(libs="$(LIBS)"; $(MMakeLinkCApp))
 
 zmq_subscriber: zmq_subscriber.o


### PR DESCRIPTION
This is a fixup for 99d863f2a08091050438af9e8cdf94fefb133cb5

Without this commit even after deleting a build, the file /src/tools/ip/libstack.o remains present. This is a unique object file that is not located in the /build/ directory.
If we build Onload on one host, remove build and then build on another with different system it may lead to build fail.
