### PR TITLE
timestamp: Extend TTAG and BRCM trailer timestamps with wall clock time

### DIFF
--- a/src/include/ci/internal/ip_timestamp.h
+++ b/src/include/ci/internal/ip_timestamp.h
@@ -7,6 +7,16 @@
 #include <onload/extensions_timestamping.h>
 
 #if CI_CFG_TIMESTAMPING
+
+#ifdef CI_UNIT_MOCK_TIMESYNC_WALLCLOCK
+extern struct oo_timespec mocked_timesync_wallclock;
+#elif defined(__KERNEL__)
+# include <onload/tcp_driver.h>
+#else
+# include <onload/ul/per_thread.h>
+extern void ci_synchronise_clock(ci_netif *ni, struct oo_timesync* oo_ts_local);
+#endif
+
 enum {
   /* PART 1
    * The following values need to match their counterparts in
@@ -228,9 +238,49 @@ ci_rx_pkt_timestamp_cpacket(struct onload_timestamp* ts_out,
   }
 }
 
+static inline uint64_t
+ci_timestamp_extend_generic(uint64_t ts, uint64_t ref_ts,
+                            uint64_t max_tolerance,
+                            uint8_t valid_bits)
+{
+  uint64_t wrap, mask, ref_lo, delta;
+
+  wrap = 1ULL << valid_bits;
+  mask = wrap - 1;
+  ref_lo = ref_ts & mask;
+  /* ts should not have any of the higher bits set */
+  ci_assert(!(ts & ~mask));
+
+  /* The delta should satisfy modular arithmetic rules, mod the value of wrap.
+   *
+   * As an example, for a valid_bits = 4 (i.e. wrap = 16),
+   * a number on the high end subtracted by a number on the low end,
+   * such as 14 - 2, should be treated the same as a low negative minus
+   * a low positive, in this case (-2) - 2. The evaluation is different
+   * in u64, but masking to only bits in the field yields identical values.
+   */
+  delta = (ts - ref_lo) & mask;
+
+  if( delta > wrap / 2 ) {
+    /* In the previous example, delta after mask is 12, same as -4.
+     * Since delta is greater than wrap / 2 = 8, we know the negative is
+     * closer to 0. This wrap - delta normalizes the delta to the
+     * absolute value of the negative version */
+    delta = wrap - delta;
+    if( CI_UNLIKELY(delta > max_tolerance) )
+      return ~0ULL;
+    return ref_ts - delta;
+  } else {
+    if( CI_UNLIKELY(delta > max_tolerance) )
+      return ~0ULL;
+    return ref_ts + delta;
+  }
+}
+
 static inline void
 ci_rx_pkt_timestamp_ttag(struct onload_timestamp* ts_out,
-                         const char *buf_end, const char *pkt_end)
+                         const char *buf_end, const char *pkt_end,
+                         const struct oo_timespec *refclock)
 {
   struct ttag {
     uint8_t ts[6];       /* 48b nsecs */
@@ -238,14 +288,21 @@ ci_rx_pkt_timestamp_ttag(struct onload_timestamp* ts_out,
 
   const struct ttag* ttag = (const struct ttag*)buf_end - 1;
   const uint64_t nsec_per_sec = 1000ULL * 1000 * 1000;
-  uint64_t ts;
+  uint64_t ref_ts, ts;
 
   if( buf_end - pkt_end < sizeof(struct ttag) )
     return;
 
+  /* 64bit nanoseconds is lossless till year 2554 */
+  ref_ts = refclock->tv_sec * nsec_per_sec + refclock->tv_nsec;
   ts = ((uint64_t)ttag->ts[0] << 40) | ((uint64_t)ttag->ts[1] << 32) |
        ((uint64_t)ttag->ts[2] << 24) | ((uint64_t)ttag->ts[3] << 16) |
        ((uint64_t)ttag->ts[4] << 8)  | ((uint64_t)ttag->ts[5]);
+
+  /* Huge overestimation of worst case prop delay: 1 hour. */
+  ts = ci_timestamp_extend_generic(ts, ref_ts, 3600 * nsec_per_sec, 48);
+  if( ts == ~0ULL )
+    return;
 
   ts_out->sec = ts / nsec_per_sec;
   ts_out->nsec = ts - (ts_out->sec * nsec_per_sec);
@@ -255,7 +312,8 @@ ci_rx_pkt_timestamp_ttag(struct onload_timestamp* ts_out,
 
 static inline void
 ci_rx_pkt_timestamp_brcm(struct onload_timestamp* ts_out,
-                         const char *buf_end, const char *pkt_end)
+                         const char *buf_end, const char *pkt_end,
+                         const struct oo_timespec *refclock)
 {
   struct brcm_trailer {
     uint8_t ts[6];      /* 48b timestamp: 18b sec + 30b nsec */
@@ -275,6 +333,15 @@ ci_rx_pkt_timestamp_brcm(struct onload_timestamp* ts_out,
   ts_out->sec = ((uint32_t)(tt->ts[0]) << 10) |
                 ((uint32_t)(tt->ts[1]) << 2) |
                 (tt->ts[2] >> 6);
+
+  /* As above, worst case prop delay: 1 hour. */
+  ts_out->sec = ci_timestamp_extend_generic(ts_out->sec, refclock->tv_sec,
+                                            3600, 18);
+  if( ts_out->sec == ~0ULL ) {
+    ts_out->sec = 0;
+    return;
+  }
+
   ts_out->nsec = ((tt->ts[2] & 0x3F) << 24) |
                  ((uint32_t)(tt->ts[3]) << 16) |
                  ((uint32_t)(tt->ts[4]) << 8) |
@@ -283,9 +350,24 @@ ci_rx_pkt_timestamp_brcm(struct onload_timestamp* ts_out,
   ts_out->flags = 0;
 }
 
+static inline const struct oo_timespec *
+ci_rx_pkt_timestamp_refclock(ci_netif *ni)
+{
+#ifdef CI_UNIT_MOCK_TIMESYNC_WALLCLOCK
+  return &mocked_timesync_wallclock;
+#elif defined(__KERNEL__)
+  return &efab_tcp_driver.timesync->wall_clock;
+#else
+  struct oo_timesync *oo_ts_local = &(__oo_per_thread_get()->timesync);
+  ci_synchronise_clock(ni, oo_ts_local);
+  return &oo_ts_local->wall_clock;
+#endif
+}
+
 static inline void
 ci_rx_pkt_timestamp_trailer(const ci_ip_pkt_fmt* pkt,
-                            struct onload_timestamp* ts_out, int format)
+                            struct onload_timestamp* ts_out, int format,
+                            ci_netif *ni)
 {
   const char *buf_end, *pkt_end;
 
@@ -304,16 +386,18 @@ ci_rx_pkt_timestamp_trailer(const ci_ip_pkt_fmt* pkt,
     ci_rx_pkt_timestamp_cpacket(ts_out, buf_end, pkt_end);
     break;
   case CITP_RX_TIMESTAMPING_TRAILER_FORMAT_TTAG:
-    ci_rx_pkt_timestamp_ttag(ts_out, buf_end, pkt_end);
+    ci_rx_pkt_timestamp_ttag(ts_out, buf_end, pkt_end,
+                             ci_rx_pkt_timestamp_refclock(ni));
     break;
   case CITP_RX_TIMESTAMPING_TRAILER_FORMAT_BRCM:
-    ci_rx_pkt_timestamp_brcm(ts_out, buf_end, pkt_end);
+    ci_rx_pkt_timestamp_brcm(ts_out, buf_end, pkt_end,
+                             ci_rx_pkt_timestamp_refclock(ni));
     break;
   }
 }
 
 static inline void
-ci_rx_pkt_timestamp(const ci_ip_pkt_fmt* pkt, struct onload_timestamp* ts_out,
+ci_rx_pkt_timestamp(ci_netif *ni, const ci_ip_pkt_fmt* pkt, struct onload_timestamp* ts_out,
                     int src, int format)
 {
   switch( src ) {
@@ -321,7 +405,7 @@ ci_rx_pkt_timestamp(const ci_ip_pkt_fmt* pkt, struct onload_timestamp* ts_out,
     ci_rx_pkt_timestamp_nic(pkt, ts_out);
     break;
   case CITP_RX_TIMESTAMPING_SOURCE_TRAILER:
-    ci_rx_pkt_timestamp_trailer(pkt, ts_out, format);
+    ci_rx_pkt_timestamp_trailer(pkt, ts_out, format, ni);
     break;
   default:
     ts_out->sec = 0;
@@ -330,11 +414,11 @@ ci_rx_pkt_timestamp(const ci_ip_pkt_fmt* pkt, struct onload_timestamp* ts_out,
 }
 
 static inline void
-ci_rx_pkt_timespec(const ci_ip_pkt_fmt* pkt, ef_timespec* ts_out, int src,
-                   int trailer_type)
+ci_rx_pkt_timespec(ci_netif *ni, const ci_ip_pkt_fmt* pkt,
+                   ef_timespec* ts_out, int src, int trailer_type)
 {
   struct onload_timestamp ts;
-  ci_rx_pkt_timestamp(pkt, &ts, src, trailer_type);
+  ci_rx_pkt_timestamp(ni, pkt, &ts, src, trailer_type);
   onload_timestamp_to_timespec(&ts, ts_out);
 }
 

--- a/src/lib/transport/ip/ip_cmsg.c
+++ b/src/lib/transport/ip/ip_cmsg.c
@@ -352,7 +352,7 @@ void ip_cmsg_recv_timestamping(ci_netif *ni, const ci_ip_pkt_fmt *pkt,
       (flags & ONLOAD_SOF_TIMESTAMPING_ONLOAD_V2 &&
        flags & ONLOAD_SOF_TIMESTAMPING_TRAILER) )
     ci_rx_pkt_timestamp_trailer(pkt, &trailertime,
-                                NI_OPTS(ni).rx_timestamping_trailer_fmt);
+                                NI_OPTS(ni).rx_timestamping_trailer_fmt, ni);
 
   /* Populate extension API v1 timestamps */
   if( flags & ONLOAD_SOF_TIMESTAMPING_ONLOAD ) {

--- a/src/lib/transport/unix/tcp_fd.c
+++ b/src/lib/transport/unix/tcp_fd.c
@@ -2163,7 +2163,7 @@ citp_tcp_ordered_data(citp_fdinfo* fdi, struct timespec* limit,
 
     do {
       struct timespec stamp;
-      ci_rx_pkt_timespec(pkt, &stamp,
+      ci_rx_pkt_timespec(epi->sock.netif, pkt, &stamp,
                          NI_OPTS(epi->sock.netif).rx_timestamping_ordering,
                          NI_OPTS(epi->sock.netif).rx_timestamping_trailer_fmt);
 

--- a/src/lib/transport/unix/udp_fd.c
+++ b/src/lib/transport/unix/udp_fd.c
@@ -714,7 +714,7 @@ citp_udp_ordered_data(citp_fdinfo* fdi, struct timespec* limit,
 
   do {
     struct timespec stamp;
-    ci_rx_pkt_timespec(pkt, &stamp,
+    ci_rx_pkt_timespec(epi->sock.netif, pkt, &stamp,
                        NI_OPTS(epi->sock.netif).rx_timestamping_ordering,
                        NI_OPTS(epi->sock.netif).rx_timestamping_trailer_fmt);
 

--- a/src/tests/unit/header/ci/internal/ip_timestamp.c
+++ b/src/tests/unit/header/ci/internal/ip_timestamp.c
@@ -2,11 +2,20 @@
 /* X-SPDX-Copyright-Text: (c) Copyright 2023 Xilinx, Inc. */
 
 /* Functions under test */
+#define CI_UNIT_MOCK_TIMESYNC_WALLCLOCK
 #include <ci/internal/ip_timestamp.h>
 
 /* Test infrastructure */
 #include "unit_test.h"
 #include <ci/net/ipv4.h>
+
+/* Helpers to mock wall clock, to extend certain trailer timestamp formats */
+struct oo_timespec mocked_timesync_wallclock;
+static void mock_wallclock_set(ci_int64 sec, ci_uint32 nsec)
+{
+  mocked_timesync_wallclock.tv_sec = sec;
+  mocked_timesync_wallclock.tv_nsec = nsec;
+}
 
 /* Helpers to build packets with trailers */
 union pkt_buf {
@@ -174,7 +183,8 @@ static void test_rx_pkt_timestamp_cpacket_none(void)
   pkt_udp(pkt, NULL, 0);
   STATE_STASH(buf);
 
-  ci_rx_pkt_timestamp_trailer(pkt, ts, CITP_RX_TIMESTAMPING_TRAILER_FORMAT_CPACKET);
+  ci_rx_pkt_timestamp_trailer(pkt, ts, CITP_RX_TIMESTAMPING_TRAILER_FORMAT_CPACKET,
+                              NULL);
   STATE_CHECK(ts, sec, 0);
 
   STATE_FREE(buf);
@@ -197,7 +207,8 @@ static void test_rx_pkt_timestamp_cpacket_basic(void)
   pkt_cpacket(pkt, sec, nsec);
   STATE_STASH(buf);
 
-  ci_rx_pkt_timestamp_trailer(pkt, ts, CITP_RX_TIMESTAMPING_TRAILER_FORMAT_CPACKET);
+  ci_rx_pkt_timestamp_trailer(pkt, ts, CITP_RX_TIMESTAMPING_TRAILER_FORMAT_CPACKET,
+                              NULL);
   STATE_CHECK(ts, sec, sec);
   STATE_CHECK(ts, nsec, nsec);
 
@@ -223,7 +234,8 @@ static void test_rx_pkt_timestamp_cpacket_subnano(void)
   pkt_cpacket(pkt, sec, nsec);
   STATE_STASH(buf);
 
-  ci_rx_pkt_timestamp_trailer(pkt, ts, CITP_RX_TIMESTAMPING_TRAILER_FORMAT_CPACKET);
+  ci_rx_pkt_timestamp_trailer(pkt, ts, CITP_RX_TIMESTAMPING_TRAILER_FORMAT_CPACKET,
+                              NULL);
   STATE_CHECK(ts, sec, sec);
   STATE_CHECK(ts, nsec, nsec);
   STATE_CHECK_BF(ts, nsec_frac, subnano);
@@ -258,7 +270,8 @@ static void test_rx_pkt_timestamp_cpacket_many(void)
   pkt_cpacket(pkt, sec, nsec);
   STATE_STASH(buf);
 
-  ci_rx_pkt_timestamp_trailer(pkt, ts, CITP_RX_TIMESTAMPING_TRAILER_FORMAT_CPACKET);
+  ci_rx_pkt_timestamp_trailer(pkt, ts, CITP_RX_TIMESTAMPING_TRAILER_FORMAT_CPACKET,
+                              NULL);
   STATE_CHECK(ts, sec, sec);
   STATE_CHECK(ts, nsec, nsec);
   STATE_CHECK_BF(ts, nsec_frac, subnano);
@@ -288,7 +301,8 @@ static void test_rx_pkt_timestamp_cpacket_bogus(void)
   pkt_cpacket(pkt, sec, nsec);
   STATE_STASH(buf);
 
-  ci_rx_pkt_timestamp_trailer(pkt, ts, CITP_RX_TIMESTAMPING_TRAILER_FORMAT_CPACKET);
+  ci_rx_pkt_timestamp_trailer(pkt, ts, CITP_RX_TIMESTAMPING_TRAILER_FORMAT_CPACKET,
+                              NULL);
   STATE_CHECK(ts, sec, sec);
   STATE_CHECK(ts, nsec, nsec);
   STATE_CHECK_BF(ts, nsec_frac, 0); /* didn't find it, but no disastrous outcome */
@@ -409,7 +423,8 @@ static void test_rx_pkt_timestamp_cpacket_pcap_metawatch(void)
   pkt_append(pkt, pcap, sizeof(pcap));
   STATE_STASH(buf);
 
-  ci_rx_pkt_timestamp_trailer(pkt, ts, CITP_RX_TIMESTAMPING_TRAILER_FORMAT_CPACKET);
+  ci_rx_pkt_timestamp_trailer(pkt, ts, CITP_RX_TIMESTAMPING_TRAILER_FORMAT_CPACKET,
+                              NULL);
   STATE_CHECK(ts, sec, 0x5c9a4c08);
   STATE_CHECK(ts, nsec, 0x313ac683);
   STATE_CHECK_BF(ts, nsec_frac, 0x536c8b);
@@ -473,7 +488,8 @@ static void test_rx_pkt_timestamp_cpacket_pcap_wireshark(void)
   pkt_append(pkt, pcap, sizeof(pcap));
   STATE_STASH(buf);
 
-  ci_rx_pkt_timestamp_trailer(pkt, ts, CITP_RX_TIMESTAMPING_TRAILER_FORMAT_CPACKET);
+  ci_rx_pkt_timestamp_trailer(pkt, ts, CITP_RX_TIMESTAMPING_TRAILER_FORMAT_CPACKET,
+                              NULL);
   STATE_CHECK(ts, sec, 0x40a34b24);
   STATE_CHECK(ts, nsec, 0x0d4399db);
   STATE_CHECK_BF(ts, nsec_frac, 0x2c52de);
@@ -482,13 +498,14 @@ static void test_rx_pkt_timestamp_cpacket_pcap_wireshark(void)
   STATE_FREE(ts);
 }
 
-static void test_rx_pkt_timestamp_trailer_ttag(void)
+static void test_rx_pkt_timestamp_trailer_ttag_simple_before(void)
 {
   const uint64_t nsec_per_sec = 1000ULL * 1000 * 1000;
-  const uint64_t max_48b_nsec = (1UL << 48) - 1;
   ci_ip_pkt_fmt* pkt;
-  uint32_t sec = (max_48b_nsec / nsec_per_sec) - 1;
-  uint32_t nsec = 999999999;
+  uint64_t ns64 = 0x1234567890abcdefULL;
+  uint64_t ns48 = ns64 & 0xffffffffffffULL;
+  uint64_t sec = ns64 / nsec_per_sec;
+  uint32_t nsec = ns64 % nsec_per_sec;
 
   STATE_ALLOC(union pkt_buf, buf);
   STATE_ALLOC(struct onload_timestamp, ts);
@@ -496,10 +513,13 @@ static void test_rx_pkt_timestamp_trailer_ttag(void)
   pkt = &buf->pkt;
   pkt_init(pkt);
   pkt_udp(pkt, NULL, 0);
-  pkt_ttag(pkt, sec, nsec);
+  pkt_ttag(pkt, ns48 / nsec_per_sec, ns48 % nsec_per_sec);
   STATE_STASH(buf);
 
-  ci_rx_pkt_timestamp_trailer(pkt, ts, CITP_RX_TIMESTAMPING_TRAILER_FORMAT_TTAG);
+  /* Trailer timestamp is a couple seconds behind wallclock */
+  mock_wallclock_set(sec + 5, 123456789);
+  ci_rx_pkt_timestamp_trailer(pkt, ts, CITP_RX_TIMESTAMPING_TRAILER_FORMAT_TTAG,
+                              NULL);
   STATE_CHECK(ts, sec, sec);
   STATE_CHECK(ts, nsec, nsec);
   STATE_CHECK_BF(ts, nsec_frac, 0);
@@ -508,11 +528,134 @@ static void test_rx_pkt_timestamp_trailer_ttag(void)
   STATE_FREE(ts);
 }
 
-static void test_rx_pkt_timestamp_trailer_brcm(void)
+static void test_rx_pkt_timestamp_trailer_ttag_simple_after(void)
+{
+  const uint64_t nsec_per_sec = 1000ULL * 1000 * 1000;
+  ci_ip_pkt_fmt* pkt;
+  uint64_t ns64 = 0x234567890abcdef1ULL;
+  uint64_t ns48 = ns64 & 0xffffffffffffULL;
+  uint64_t sec = ns64 / nsec_per_sec;
+  uint32_t nsec = ns64 % nsec_per_sec;
+
+  STATE_ALLOC(union pkt_buf, buf);
+  STATE_ALLOC(struct onload_timestamp, ts);
+
+  pkt = &buf->pkt;
+  pkt_init(pkt);
+  pkt_udp(pkt, NULL, 0);
+  pkt_ttag(pkt, ns48 / nsec_per_sec, ns48 % nsec_per_sec);
+  STATE_STASH(buf);
+
+  /* Trailer timestamp is a couple seconds ahead of wallclock */
+  mock_wallclock_set(sec - 5, 234567890);
+  ci_rx_pkt_timestamp_trailer(pkt, ts, CITP_RX_TIMESTAMPING_TRAILER_FORMAT_TTAG,
+                              NULL);
+  STATE_CHECK(ts, sec, sec);
+  STATE_CHECK(ts, nsec, nsec);
+  STATE_CHECK_BF(ts, nsec_frac, 0);
+
+  STATE_FREE(buf);
+  STATE_FREE(ts);
+}
+
+static void test_rx_pkt_timestamp_trailer_ttag_wraparound_before(void)
+{
+  const uint64_t nsec_per_sec = 1000ULL * 1000 * 1000;
+  ci_ip_pkt_fmt* pkt;
+  uint64_t ns64 = 0x3456000000000000ULL - 2 * nsec_per_sec - 987654321;
+  uint64_t ns48 = ns64 & 0xffffffffffffULL;
+  uint64_t sec = ns64 / nsec_per_sec;
+  uint32_t nsec = ns64 % nsec_per_sec;
+
+  STATE_ALLOC(union pkt_buf, buf);
+  STATE_ALLOC(struct onload_timestamp, ts);
+
+  pkt = &buf->pkt;
+  pkt_init(pkt);
+  pkt_udp(pkt, NULL, 0);
+  pkt_ttag(pkt, ns48 / nsec_per_sec, ns48 % nsec_per_sec);
+  STATE_STASH(buf);
+
+  /* Trailer timestamp is a couple seconds behind wallclock.
+   * The ns48 of wall clock has wrapped but trailer has not */
+  mock_wallclock_set(sec + 5, 345678901);
+  ci_rx_pkt_timestamp_trailer(pkt, ts, CITP_RX_TIMESTAMPING_TRAILER_FORMAT_TTAG,
+                              NULL);
+  STATE_CHECK(ts, sec, sec);
+  STATE_CHECK(ts, nsec, nsec);
+  STATE_CHECK_BF(ts, nsec_frac, 0);
+
+  STATE_FREE(buf);
+  STATE_FREE(ts);
+}
+
+static void test_rx_pkt_timestamp_trailer_ttag_wraparound_after(void)
+{
+  const uint64_t nsec_per_sec = 1000ULL * 1000 * 1000;
+  ci_ip_pkt_fmt* pkt;
+  uint64_t ns64 = 0x4567000000000000ULL + 2 * nsec_per_sec + 876543210;
+  uint64_t ns48 = ns64 & 0xffffffffffffULL;
+  uint64_t sec = ns64 / nsec_per_sec;
+  uint32_t nsec = ns64 % nsec_per_sec;
+
+  STATE_ALLOC(union pkt_buf, buf);
+  STATE_ALLOC(struct onload_timestamp, ts);
+
+  pkt = &buf->pkt;
+  pkt_init(pkt);
+  pkt_udp(pkt, NULL, 0);
+  pkt_ttag(pkt, ns48 / nsec_per_sec, ns48 % nsec_per_sec);
+  STATE_STASH(buf);
+
+  /* Trailer timestamp is a couple seconds ahead of wallclock.
+   * The trailer has wrapped but ns48 of wall clock has not */
+  mock_wallclock_set(sec - 5, 456789012);
+  ci_rx_pkt_timestamp_trailer(pkt, ts, CITP_RX_TIMESTAMPING_TRAILER_FORMAT_TTAG,
+                              NULL);
+  STATE_CHECK(ts, sec, sec);
+  STATE_CHECK(ts, nsec, nsec);
+  STATE_CHECK_BF(ts, nsec_frac, 0);
+
+  STATE_FREE(buf);
+  STATE_FREE(ts);
+}
+
+static void test_rx_pkt_timestamp_trailer_ttag_oob(void)
+{
+  const uint64_t nsec_per_sec = 1000ULL * 1000 * 1000;
+  ci_ip_pkt_fmt* pkt;
+  uint64_t ns64 = 0x567890abcdef1234ULL;
+  uint64_t ns48 = (ns64 + 24 * 3600 * nsec_per_sec) & 0xffffffffffffULL;
+  uint64_t sec = ns64 / nsec_per_sec;
+  uint32_t nsec = ns64 % nsec_per_sec;
+
+  STATE_ALLOC(union pkt_buf, buf);
+  STATE_ALLOC(struct onload_timestamp, ts);
+
+  pkt = &buf->pkt;
+  pkt_init(pkt);
+  pkt_udp(pkt, NULL, 0);
+  pkt_ttag(pkt, ns48 / nsec_per_sec, ns48 % nsec_per_sec);
+  STATE_STASH(buf);
+
+  /* Trailer timestamp and wall clock is off by a day, consider as invalid */
+  mock_wallclock_set(sec, nsec);
+  ci_rx_pkt_timestamp_trailer(pkt, ts, CITP_RX_TIMESTAMPING_TRAILER_FORMAT_TTAG,
+                              NULL);
+  STATE_CHECK(ts, sec, 0);
+  STATE_CHECK(ts, nsec, 0);
+  STATE_CHECK_BF(ts, nsec_frac, 0);
+
+  STATE_FREE(buf);
+  STATE_FREE(ts);
+}
+
+static void test_rx_pkt_timestamp_trailer_brcm_simple_before(void)
 {
   ci_ip_pkt_fmt* pkt;
-  uint32_t sec = 0x3FFFF;	/* largest 18b value */
-  uint32_t nsec = 999999999;
+  uint64_t wallsecupper = 0x123400000ULL;
+  uint32_t sec = 0x12345;
+  uint32_t nsec = 123456789;
 
   STATE_ALLOC(union pkt_buf, buf);
   STATE_ALLOC(struct onload_timestamp, ts);
@@ -523,9 +666,125 @@ static void test_rx_pkt_timestamp_trailer_brcm(void)
   pkt_trailer_brcm(pkt, sec, nsec);
   STATE_STASH(buf);
 
-  ci_rx_pkt_timestamp_trailer(pkt, ts, CITP_RX_TIMESTAMPING_TRAILER_FORMAT_BRCM);
-  STATE_CHECK(ts, sec, sec);
+  /* Trailer timestamp is a couple seconds behind wallclock */
+  mock_wallclock_set(wallsecupper + sec + 5, 987654321);
+  ci_rx_pkt_timestamp_trailer(pkt, ts, CITP_RX_TIMESTAMPING_TRAILER_FORMAT_BRCM,
+                              NULL);
+  STATE_CHECK(ts, sec, wallsecupper + sec);
   STATE_CHECK(ts, nsec, nsec);
+  STATE_CHECK_BF(ts, nsec_frac, 0);
+
+  STATE_FREE(buf);
+  STATE_FREE(ts);
+}
+
+static void test_rx_pkt_timestamp_trailer_brcm_simple_after(void)
+{
+  ci_ip_pkt_fmt* pkt;
+  uint64_t wallsecupper = 0x234100000ULL;
+  uint32_t sec = 0x23456;
+  uint32_t nsec = 234567890;
+
+  STATE_ALLOC(union pkt_buf, buf);
+  STATE_ALLOC(struct onload_timestamp, ts);
+
+  pkt = &buf->pkt;
+  pkt_init(pkt);
+  pkt_udp(pkt, NULL, 0);
+  pkt_trailer_brcm(pkt, sec, nsec);
+  STATE_STASH(buf);
+
+  /* Trailer timestamp is a couple seconds ahead of wallclock */
+  mock_wallclock_set(wallsecupper + sec - 5, 876543210);
+  ci_rx_pkt_timestamp_trailer(pkt, ts, CITP_RX_TIMESTAMPING_TRAILER_FORMAT_BRCM,
+                              NULL);
+  STATE_CHECK(ts, sec, wallsecupper + sec);
+  STATE_CHECK(ts, nsec, nsec);
+  STATE_CHECK_BF(ts, nsec_frac, 0);
+
+  STATE_FREE(buf);
+  STATE_FREE(ts);
+}
+
+static void test_rx_pkt_timestamp_trailer_brcm_wraparound_before(void)
+{
+  ci_ip_pkt_fmt* pkt;
+  uint64_t wallsecupper = 0x341200000ULL;
+  uint32_t secoff = 2;
+  uint32_t nsec = 345678901;
+
+  STATE_ALLOC(union pkt_buf, buf);
+  STATE_ALLOC(struct onload_timestamp, ts);
+
+  pkt = &buf->pkt;
+  pkt_init(pkt);
+  pkt_udp(pkt, NULL, 0);
+  pkt_trailer_brcm(pkt, 0x40000 - secoff, nsec);
+  STATE_STASH(buf);
+
+  /* Trailer timestamp is a couple seconds behind wallclock.
+   * The ns48 of wall clock has wrapped but trailer has not */
+  mock_wallclock_set(wallsecupper + 5, 765432109);
+  ci_rx_pkt_timestamp_trailer(pkt, ts, CITP_RX_TIMESTAMPING_TRAILER_FORMAT_BRCM,
+                              NULL);
+  STATE_CHECK(ts, sec, wallsecupper - secoff);
+  STATE_CHECK(ts, nsec, nsec);
+  STATE_CHECK_BF(ts, nsec_frac, 0);
+
+  STATE_FREE(buf);
+  STATE_FREE(ts);
+}
+
+static void test_rx_pkt_timestamp_trailer_brcm_wraparound_after(void)
+{
+  ci_ip_pkt_fmt* pkt;
+  uint64_t wallsecupper = 0x412300000ULL;
+  uint32_t secoff = 2;
+  uint32_t nsec = 456789012;
+
+  STATE_ALLOC(union pkt_buf, buf);
+  STATE_ALLOC(struct onload_timestamp, ts);
+
+  pkt = &buf->pkt;
+  pkt_init(pkt);
+  pkt_udp(pkt, NULL, 0);
+  pkt_trailer_brcm(pkt, secoff, nsec);
+  STATE_STASH(buf);
+
+  /* Trailer timestamp is a couple seconds ahead of wallclock.
+   * The trailer has wrapped but ns48 of wall clock has not */
+  mock_wallclock_set(wallsecupper - 5, 765432109);
+  ci_rx_pkt_timestamp_trailer(pkt, ts, CITP_RX_TIMESTAMPING_TRAILER_FORMAT_BRCM,
+                              NULL);
+  STATE_CHECK(ts, sec, wallsecupper + secoff);
+  STATE_CHECK(ts, nsec, nsec);
+  STATE_CHECK_BF(ts, nsec_frac, 0);
+
+  STATE_FREE(buf);
+  STATE_FREE(ts);
+}
+
+static void test_rx_pkt_timestamp_trailer_brcm_oob(void)
+{
+  ci_ip_pkt_fmt* pkt;
+  uint64_t wallsecupper = 0x123400000ULL;
+  uint32_t nsec = 567890123;
+
+  STATE_ALLOC(union pkt_buf, buf);
+  STATE_ALLOC(struct onload_timestamp, ts);
+
+  pkt = &buf->pkt;
+  pkt_init(pkt);
+  pkt_udp(pkt, NULL, 0);
+  pkt_trailer_brcm(pkt, 24 * 3600, nsec);
+  STATE_STASH(buf);
+
+  /* Trailer timestamp and wall clock is off by a day, consider as invalid */
+  mock_wallclock_set(wallsecupper, 654321098);
+  ci_rx_pkt_timestamp_trailer(pkt, ts, CITP_RX_TIMESTAMPING_TRAILER_FORMAT_BRCM,
+                              NULL);
+  STATE_CHECK(ts, sec, 0);
+  STATE_CHECK(ts, nsec, 0);
   STATE_CHECK_BF(ts, nsec_frac, 0);
 
   STATE_FREE(buf);
@@ -540,7 +799,15 @@ int main(void) {
   TEST_RUN(test_rx_pkt_timestamp_cpacket_bogus);
   TEST_RUN(test_rx_pkt_timestamp_cpacket_pcap_metawatch);
   TEST_RUN(test_rx_pkt_timestamp_cpacket_pcap_wireshark);
-  TEST_RUN(test_rx_pkt_timestamp_trailer_ttag);
-  TEST_RUN(test_rx_pkt_timestamp_trailer_brcm);
+  TEST_RUN(test_rx_pkt_timestamp_trailer_ttag_simple_before);
+  TEST_RUN(test_rx_pkt_timestamp_trailer_ttag_simple_after);
+  TEST_RUN(test_rx_pkt_timestamp_trailer_ttag_wraparound_before);
+  TEST_RUN(test_rx_pkt_timestamp_trailer_ttag_wraparound_after);
+  TEST_RUN(test_rx_pkt_timestamp_trailer_ttag_oob);
+  TEST_RUN(test_rx_pkt_timestamp_trailer_brcm_simple_before);
+  TEST_RUN(test_rx_pkt_timestamp_trailer_brcm_simple_after);
+  TEST_RUN(test_rx_pkt_timestamp_trailer_brcm_wraparound_before);
+  TEST_RUN(test_rx_pkt_timestamp_trailer_brcm_wraparound_after);
+  TEST_RUN(test_rx_pkt_timestamp_trailer_brcm_oob);
   TEST_END();
 }

--- a/src/tests/unit/stubs.c
+++ b/src/tests/unit/stubs.c
@@ -17,5 +17,8 @@ __attribute__ ((weak)) int  (*ci_sys_ioctl)(int, long unsigned int, ...) = NULL;
 __attribute__ ((weak)) void ci_log(const char* fmt, ...) {}
 __attribute__ ((weak)) void ef_log(const char* fmt, ...) {}
 
+/* Allow the unit test to call __ci_fail (used by ci_assert) by aborting */
+__attribute__ ((weak)) void __ci_fail(const char* fmt, ...) { abort(); }
+
 __attribute__ ((weak))
 void ef_vi_init_resource_alloc(ci_resource_alloc_t *alloc, uint32_t type) {}


### PR DESCRIPTION
TTAG is ns48, and BRCM is s18 + ns30. In both cases, there is a wraparound every ~3 days. During this, wire-order delivery may fail, since it will see a packet that is later in the wire order, have a lower timestamp than a packet that is earlier than the wire order. This is not needed for the third trailer format, cPacket, which encodes s32 + ns32, which will not wraparound till year 2106.

This extends the trailer timestamps with the wall clock time from the driver, and accepts the closest time in ns64 to the wall clock time that matches the given trailer timestamp, with maximum accepted difference of an hour in both directions. An hour is long enough to satisfy any practical propagation delay. The mechanism is similar e.g., to TCP PAWS which handles 32-bit seqno wrap. Only a subset of the option space is considered valid. In this case an hour plus or minus the current host clock, out of a three day precision. This allows identifying both time ahead of and behind the host clock.

A lot of unit tests have been added to verify the correctness of this extension operation, since it can be difficult to mentally model the maths for it. The tests are named:
- simple_before: trailer timestamp is behind wallclock, with no wraparound
- simple_after: trailer timestamp is ahead of wallclock, with no wraparound
- wraparound_before: trailer timestamp is behind wallclock, having the equivalent trailer timestamp of the wall clock experience a wraparound but the actual trailer timestamp has not.
- wraparound_after: trailer timestamp is ahead of wallclock, having the actual trailer timestamp experience a wraparound but the equivalent trailer timestamp of the wall clock has not
- oob: the difference of trailer timestamp and wall clock exceed the maximum accepted bounds of propagation delay.

Additionally, integration has also been tested with rx_timestamping program with a Broadcom switch to append the timestamps:

```
$ EF_RX_TIMESTAMPING_TRAILER_FORMAT=brcm EF_RX_TIMESTAMPING=3 \
> onload tests/onload/hwtimestamping/rx_timestamping --proto TCP -E
oo:rx_timestamping[30320]: Using Onload 3dc43610b 2026-04-07 [...]  [6]
oo:rx_timestamping[30320]: Copyright (c) 2002-2026 Advanced Micro Devices, Inc.
Socket created, listening on port 9000
Socket accepted
Selecting hardware timestamping mode.
Packet 1 - 2 bytes	ext v2 timestamps rx.sw 1775607969.777881134000 --✘ rx.hw 1775607969.777876198000 --✘ rx.trailer 1775607969.777869393000 --✘
Packet 2 - 0 bytes
recvmsg returned 0 - end of stream
```

Also tested with tests/onload/wire_order/wire_order_{client,server} with EF_RX_TIMESTAMPING_ORDERING=trailer EF_RX_TIMESTAMPING_TRAILER_FORMAT=brcm with 12 sockets over 100 iterations without a sequence error.