### PR TITLE
tools/ip: avoid segfault in stackdump if libpcap-dev is missing

### DIFF
--- a/src/tools/ip/libstack.c
+++ b/src/tools/ip/libstack.c
@@ -2891,11 +2891,11 @@ static void signal_handler(int signum)
 
 int libstack_init()
 {
+  ci_set_log_prefix("");
+  ci_dllist_init(&stacks_list);
   if( cfg_filter )
     if( ! sockbuf_filter_prepare(&sft, cfg_filter) )
       return -1;
-  ci_set_log_prefix("");
-  ci_dllist_init(&stacks_list);
   if( libstack_mappings_init() )
     return -1;
   CI_TEST(signal(SIGUSR1, signal_handler) != SIG_ERR);


### PR DESCRIPTION
Initialize 'stacks_list' before calling sockbuf_filter_prepare() to avoid using it uninitialized on exit.

Before the patch (on Ubuntu without libpcap-dev):
  $ sudo onload_stackdump --filter "dst port 80"
  Onload was compiled without the libpcap development package.
  You need to install the libpcap-devel or libpcap-dev package
  to use the --filter option of this tool.Segmentation fault