### PR TITLE
tcp: add is_dupack check to ci_tcp_rx_dupack invocation

### DIFF
--- a/src/lib/transport/ip/tcp_rx.c
+++ b/src/lib/transport/ip/tcp_rx.c
@@ -1684,7 +1684,7 @@ static void ci_tcp_rx_handle_ack(ci_tcp_state* ts, ci_netif* netif,
     if( ci_ip_queue_is_empty(&ts->retrans) ||
         (! is_dupack && ! (rxp->flags & CI_TCP_SACKED)) )
       ts->dup_acks = 0;
-    else
+    else if ( is_dupack )
       ci_tcp_rx_dupack(ts, netif, rxp);
   }
 


### PR DESCRIPTION
Bug Description:

When printing  "ts->dup_acks" inside 
"ci_tcp_rx_dupack", the value is inconsistent with the count analyzed by Wireshark under packet loss conditions. I added a print in 
"ci_tcp_rx_handle_ack" to log the "is_dupack" value when "ci_tcp_rx_dupack" is called, and sometimes it is 0. The root cause is that 
"snd_max_different" is not equal to 0, meaning TCP Window Update packets are being incorrectly identified as Dup ACK packets.

Reproduction Steps:

1. Start the server without Onload: 
"netserver -D -f"
2. Start the client with Onload: 
"onload netperf TCP_STREAM -m 8192"
3. Modify Onload code to simulate packet loss: return immediately without sending in 
"ci_ip_tcp_list_to_dmaq".The issue reproduces with high probability.