### PR TITLE
deb: DKMS packaging improvements

### DIFF
--- a/scripts/debian/debian-templ/changelog
+++ b/scripts/debian/debian-templ/changelog
@@ -1,4 +1,4 @@
-#TYPE# (#VERSION#-1) unstable; urgency=low
+#TYPE# (#VERSION#-#DEBIAN_REVISION#) unstable; urgency=low
 
   * Initial release of Debian packages
 

--- a/scripts/debian/debian-templ/control
+++ b/scripts/debian/debian-templ/control
@@ -2,7 +2,7 @@ Source: #TYPE#
 Section: net
 Priority: extra
 Maintainer: AMD Solarflare NIC Support <support-nic@amd.com>
-Build-Depends: debhelper (>= 8.0.0), bzip2, gawk, libc6, dh-python, python3-all, python3-setuptools, libpcap-dev, libcap-dev, debhelper (>= 13.3) | dh-sysuser, pybuild-plugin-pyproject
+Build-Depends: debhelper (>= 8.0.0), bzip2, gawk, libc6, dh-python, python3-all, python3-setuptools, libpcap-dev, libcap-dev, debhelper (>= 13.3) | dh-sysuser, pybuild-plugin-pyproject, dh-sequence-dkms | dh-dkms | dkms
 Standards-Version: 3.9.3
 Homepage: http://www.openonload.org
 
@@ -26,7 +26,7 @@ Build-Profiles: <!pkg.#TYPE#.nosource>
 
 Package: #TYPE#-dkms
 Architecture: all
-Depends: dkms, #TYPE#-user (>= ${source:Version}), #TYPE#-user (<< ${source:Version}.1~), ${misc:Depends}
+Depends: dkms, #TYPE#-user (>= ${source:Version}), #TYPE#-user (<< ${source:Version}.1~), libcap-dev, ${misc:Depends}
 Description: Onload debian package with DKMS
 Conflicts: #TYPE#-modules
 Build-Profiles: <!pkg.#TYPE#.nodkms>

--- a/scripts/debian/debian-templ/rules
+++ b/scripts/debian/debian-templ/rules
@@ -188,7 +188,11 @@ ifneq (,$(filter #TYPE#-source,$(DOPACKAGES)))
 	dh_installdirs -p$(psource)  usr/src/modules/$(sname)/debian
 
 	# Copy only the driver source to the proper location
-	cp Makefile  debian/$(psource)/usr/src/modules/$(sname)
+	if [ -f "debian/Makefile" ]; then \
+		cp debian/Makefile  debian/$(psource)/usr/src/modules/$(sname); \
+	else \
+		cp Makefile  debian/$(psource)/usr/src/modules/$(sname); \
+	fi
 	cp -r src  debian/$(psource)/usr/src/modules/$(sname)
 	cp -r scripts  debian/$(psource)/usr/src/modules/$(sname)
 	cp -r mk  debian/$(psource)/usr/src/modules/$(sname)
@@ -207,6 +211,20 @@ ifneq (,$(filter #TYPE#-dkms,$(DOPACKAGES)))
 	install -D -m 644 dkms_override.conf debian/$(pdkms)/etc/dkms/$(sname).conf
 	dh_installdirs -p$(pdkms) usr/src/
 	tar xf ../#TYPE#_#VERSION#.orig.tar.gz -C debian/$(pdkms)/usr/src/
+	if [ -f "debian/Makefile" ]; then \
+		install -D -m 644 debian/Makefile debian/$(pdkms)/usr/src/#TYPE#-#VERSION#/Makefile; \
+	fi
+
+	if [ -f "debian/dkms.append.conf" ]; then \
+	 	cat debian/dkms.append.conf >> debian/$(pdkms)/usr/src/#TYPE#-#VERSION#/dkms.conf; \
+	fi
+
+	if [ -f $(CURDIR)/debian/patches/series ]; then \
+		( cd debian/$(pdkms)/usr/src/#TYPE#-#VERSION# && \
+		  QUILT_PATCHES=$(CURDIR)/debian/patches \
+		  QUILT_SERIES=$(CURDIR)/debian/patches/series \
+		  quilt push -a ); \
+	fi
 endif
 
 	# Add here commands to install the package into debian/#TYPE#.
@@ -295,7 +313,7 @@ ifneq (,$(filter #TYPE#-user,$(DOPACKAGES)))
 	dh_installdirs -p$(userpackage) lib/onload
 
 	i_prefix=$(CURDIR)/debian/$(userpackage) scripts/onload_install --verbose \
-		--packaged --userfiles --modprobe --modulesloadd \
+		--packaged --userfiles --modprobe --modulesloadd --udev \
 		$(BUILD_FLAGS) $(SETUID)
 endif
 

--- a/scripts/debian/debian-templ/rules
+++ b/scripts/debian/debian-templ/rules
@@ -333,6 +333,7 @@ ifneq (,$(filter #TYPE#-user,$(DOPACKAGES)))
 
 	i_prefix=$(CURDIR)/debian/$(userpackage) scripts/onload_install --verbose \
 		--packaged --userfiles --modprobe --modulesloadd --udev \
+		$(if $(wildcard pyproject.toml),,--python-layout=deb) \
 		$(BUILD_FLAGS) $(SETUID)
 endif
 

--- a/scripts/debian/debian-templ/rules
+++ b/scripts/debian/debian-templ/rules
@@ -215,6 +215,9 @@ ifneq (,$(filter #TYPE#-dkms,$(DOPACKAGES)))
 		install -D -m 644 debian/Makefile debian/$(pdkms)/usr/src/#TYPE#-#VERSION#/Makefile; \
 	fi
 
+	if [ ! -f "debian/$(pdkms)/usr/src/#TYPE#-#VERSION#/dkms.conf" ]; then \
+		ln -s ./scripts/onload_misc/dkms.conf debian/$(pdkms)/usr/src/#TYPE#-#VERSION#/dkms.conf; \
+	fi
 	if [ -f "debian/dkms.append.conf" ]; then \
 	 	cat debian/dkms.append.conf >> debian/$(pdkms)/usr/src/#TYPE#-#VERSION#/dkms.conf; \
 	fi
@@ -247,6 +250,11 @@ binary-indep: build install
 #	dh_installpam -i
 #	dh_installmime -i
 #	dh_python3 -i
+# Let dh_dkms generate dkms-aware maintainer scripts for the dkms subpackage
+# https://manpages.debian.org/buster/dkms/dh_dkms.1
+ifneq (,$(filter #TYPE#-dkms,$(DOPACKAGES)))
+	dh_dkms -p #TYPE#-dkms -- "$(if $(wildcard dkms.conf),dkms.conf,scripts/onload_misc/dkms.conf)"
+endif
 #	dh_installinit -i
 #	dh_installcron -i
 #	dh_installinfo -i

--- a/scripts/debian/debian-templ/rules
+++ b/scripts/debian/debian-templ/rules
@@ -218,6 +218,9 @@ ifneq (,$(filter #TYPE#-dkms,$(DOPACKAGES)))
 	if [ ! -f "debian/$(pdkms)/usr/src/#TYPE#-#VERSION#/dkms.conf" ]; then \
 		ln -s ./scripts/onload_misc/dkms.conf debian/$(pdkms)/usr/src/#TYPE#-#VERSION#/dkms.conf; \
 	fi
+	if [ ! -f "debian/$(pdkms)/usr/lib/modules-load.d/onload.conf" ]; then \
+		install -D -m 644 ./scripts/onload_misc/onload_modules-load.d.conf debian/$(pdkms)/usr/lib/modules-load.d/onload.conf; \
+	fi
 	if [ -f "debian/dkms.append.conf" ]; then \
 	 	cat debian/dkms.append.conf >> debian/$(pdkms)/usr/src/#TYPE#-#VERSION#/dkms.conf; \
 	fi
@@ -233,6 +236,7 @@ endif
 	# Add here commands to install the package into debian/#TYPE#.
 
 	dh_install
+	dh_installinitramfs
 
 # Build architecture-independent files here.
 # Pass -i to all debhelper commands in this target to reduce clutter.

--- a/scripts/debian/debian-templ/rules
+++ b/scripts/debian/debian-templ/rules
@@ -16,7 +16,10 @@
 #export DH_VERBOSE=1
 
 
+# Only enable pybuild if the source ships a pyproject.toml
+ifneq (,$(wildcard pyproject.toml))
 export PYBUILD_SYSTEM=pyproject
+endif
 
 # some default definitions, important!
 #
@@ -290,7 +293,9 @@ endif
 # Build architecture-dependent files here.
 binary-arch: build install
 	dh_lintian
+ifneq (,$(wildcard pyproject.toml))
 	pybuild --verbose --build
+endif
 	dh_testdir -a
 	dh_testroot -a
 	dh_installsysusers -a --name=onload || dh_sysuser -a onload_cplane home=/run/openonload
@@ -302,8 +307,10 @@ binary-arch: build install
 #	dh_installemacsen -a
 #	dh_installpam -a
 #	dh_installmime -a
+ifneq (,$(wildcard pyproject.toml))
 	pybuild --verbose --install --dest-dir debian/$(userpackage)
 	dh_python3 -a
+endif
 #	dh_installinit -a
 	dh_installcron -a
 #	dh_installman -a

--- a/scripts/debian/debian-templ/type-dkms.initramfs-hook
+++ b/scripts/debian/debian-templ/type-dkms.initramfs-hook
@@ -1,0 +1,64 @@
+#!/bin/sh
+PREREQ=""
+prereqs()
+{
+   echo "$PREREQ"
+}
+
+case $1 in
+prereqs)
+   prereqs
+   exit 0
+   ;;
+esac
+
+. /usr/share/initramfs-tools/hook-functions
+# Begin real processing below this line
+
+# In ther future, it's possible to extend this script to a split dkms-prefer package with something like
+#
+# CONF_FILE="/etc/initramfs-tools/dkms-prefer.modules"
+# # Read module list
+# MODULES_LIST=""
+# if [ -f "$CONF_FILE" ]; then
+#   # strip comments and blanks
+#   MODULES_LIST="$(sed -e 's/#.*$//' -e '/^[[:space:]]*$/d' "$CONF_FILE")"
+# fi
+#
+# But we keep it simple for now.
+MODULES_LIST="xilinx_efct sfc"
+
+# Nothing to do?
+[ -n "${MODULES_LIST:-}" ] || exit 0
+
+# Provided by initramfs-tools
+DKMS_BASE="/lib/modules/${version}/updates/dkms"
+DEST_DKMS_DIR="${DESTDIR}${DKMS_BASE}"
+KERNEL_BASE="${DESTDIR}/lib/modules/${version}/kernel"
+
+mkdir -p "$DEST_DKMS_DIR"
+
+for mod in $MODULES_LIST; do
+  # Does *any* DKMS file for this module exist (host filesystem)?
+  if find "/lib/modules/${version}/updates/dkms" -maxdepth 1 -type f -name "${mod}.ko*" -print -quit | grep -q .; then
+    # Copy all matching DKMS files into the image (no globbing in the shell)
+    find "/lib/modules/${version}/updates/dkms" -maxdepth 1 -type f -name "${mod}.ko*" \
+    | while IFS= read -r f; do
+      [ -n "$f" ] && copy_file module "$f" "$DKMS_BASE/"
+    done
+
+
+    # Remove any in-tree copies of the same module from the image
+    if [ -d "$KERNEL_BASE" ]; then
+      find "$KERNEL_BASE" -type f -name "${mod}.ko*" -delete || true
+    fi
+
+    # Ensure dependencies get pulled in
+    manual_add_modules "$mod" || true
+    echo "initramfs-tools: using DKMS '${mod}' (updates/dkms) for ${version}" >&2
+  else
+    # No DKMS — warn and fall back to in-tree
+    echo "initramfs-tools: WARNING: DKMS module '${mod}' not found for ${version}; using in-tree if available" >&2
+    manual_add_modules "$mod" || true
+  fi
+done

--- a/scripts/debian/debian-templ/type-dkms.postinst
+++ b/scripts/debian/debian-templ/type-dkms.postinst
@@ -1,10 +1,17 @@
+#!/bin/sh
 # SPDX-License-Identifier: BSD-2-Clause
 # SPDX-FileCopyrightText: (c) Copyright 2023-2024 Advanced Micro Devices, Inc.
 
-# Remove if already exists
-dkms remove -m #TYPE# -v #VERSION# --all > /dev/null 2>&1 || true
+set -e
 
-# Build and install
-dkms add -m #TYPE# -v #VERSION#
-dkms build -m #TYPE# -v #VERSION#
-dkms install -m #TYPE# -v #VERSION# --force
+case "$1" in
+    triggered)
+        dkms autoinstall -m #TYPE# -v #VERSION# --force
+        # HACK: Force initramfs update because x3522 package does not trigger it
+        dpkg-trigger update-initramfs
+    ;;
+esac
+
+#DEBHELPER#
+
+exit 0

--- a/scripts/debian/debian-templ/type-dkms.postinst
+++ b/scripts/debian/debian-templ/type-dkms.postinst
@@ -4,11 +4,34 @@
 
 set -e
 
+install_dkms() {
+    # Remove if already exists
+    dkms remove -m #TYPE# -v #VERSION# --all > /dev/null 2>&1 || true
+
+    # Build and install
+    dkms add -m #TYPE# -v #VERSION#
+    dkms build -m #TYPE# -v #VERSION#
+    dkms install -m #TYPE# -v #VERSION# --force
+}
+
 case "$1" in
+    configure)
+        install_dkms
+    ;;
+
     triggered)
-        dkms autoinstall -m #TYPE# -v #VERSION# --force
+        install_dkms
         # HACK: Force initramfs update because x3522 package does not trigger it
         dpkg-trigger update-initramfs
+    ;;
+
+    abort-upgrade|abort-remove|abort-deconfigure)
+       exit 0
+    ;;
+
+    *)
+        echo "postinst called with unknown argument \`$1'" >&2
+        exit 1
     ;;
 esac
 

--- a/scripts/debian/debian-templ/type-dkms.prerm
+++ b/scripts/debian/debian-templ/type-dkms.prerm
@@ -1,4 +1,4 @@
 # SPDX-License-Identifier: BSD-2-Clause
 # SPDX-FileCopyrightText: (c) Copyright 2023 Advanced Micro Devices, Inc.
 
-dkms remove -m #TYPE# -v #VERSION#
+#DEBHELPER#

--- a/scripts/debian/debian-templ/type-dkms.triggers
+++ b/scripts/debian/debian-templ/type-dkms.triggers
@@ -1,0 +1,2 @@
+interest /usr/share/doc/xilinx-efct-dkms/changelog.gz
+activate-noawait update-initramfs

--- a/scripts/debian/onload_mksrcdeb.sh
+++ b/scripts/debian/onload_mksrcdeb.sh
@@ -21,6 +21,8 @@ usage() {
   err "options:"
   err "  --tarball <path>   - onload tarball to create packages for"
   err "  --out <path>       - directory to write source package to"
+  err "  --debian-revision <n>"
+  err "                     - Debian package revision (default 1)"
   err
   exit 1
 }
@@ -36,11 +38,13 @@ onloadver=
 package=
 basename=
 outdir=$(pwd)
+debian_revision=${DEBIAN_REVISION:-1}
 
 while [ $# -gt 0 ]; do
   case "$1" in
   --tarball)        shift; tarball=$1;;
   --out)            shift; outdir=$1;;
+  --debian-revision) shift; debian_revision=$1;;
   -*)               usage;;
   *)                break;;
   esac
@@ -84,7 +88,12 @@ try mkdir -p "$tempfile/$onloaddir/debian"
 # control files
 for i in $(find "$TOP"/debian/debian-templ/* -type f); do
   ni="${tempfile}/${onloaddir}/debian/$(basename "$i")"
-  try sed -e "s/#VERSION#/$onloadver/g" -e "s/#TYPE#/$onloadtype/g" -e "s/#SOVERSION#/${soversion}/g" < "$i" > "$ni";
+  try sed \
+    -e "s/#VERSION#/$onloadver/g" \
+    -e "s/#TYPE#/$onloadtype/g" \
+    -e "s/#SOVERSION#/${soversion}/g" \
+    -e "s/#DEBIAN_REVISION#/${debian_revision}/g" \
+    < "$i" > "$ni";
 done
 
 for i in $(find "${tempfile}"/"${onloaddir}"/debian/type-* -type f); do
@@ -112,4 +121,3 @@ try rm -rf "$tempfile"
 echo ""
 echo "Wrote $outdir/$package-debiansource.tgz"
 echo ""
-

--- a/scripts/onload_mkpackage
+++ b/scripts/onload_mkpackage
@@ -215,7 +215,7 @@ build_sdeb() {
   try rm -rf "${sdeb_dir:?}/*"
   try mkdir -p "$sdeb_dir"
   maybe_install debuild
-  mksrcdeb_args=(--tarball "$tarball_path" --out "$sdeb_dir")
+  mksrcdeb_args+=(--tarball "$tarball_path" --out "$sdeb_dir")
   trylog "$sdeb_dir/build.log" \
     "$bin/debian/onload_mksrcdeb.sh" "${mksrcdeb_args[@]}"
   local debiansource_paths=("$sdeb_dir"/*debiansource.tgz)
@@ -373,6 +373,7 @@ read_args() {
   fi
 }
 read_args mkdist_args
+read_args mksrcdeb_args
 read_args rpmbuild_args
 read_args rpmbuild_source_args
 read_args rpmbuild_binary_args
@@ -431,6 +432,7 @@ usage() {
   err "Env vars:"
   err "  KVER                             Sets kernel version (--kernelver)"
   err "  mkdist_args                      Extra params for onload_mkdist"
+  err "  mksrcdeb_args                    Extra params for onload_mksrcdeb"
   err "  rpmbuild_args                    Extra params for all rpmbuild builds"
   err "  rpmbuild_source_args             Extra params for rpmbuild source build"
   err "  rpmbuild_binary_args             Extra params for rpmbuild binary build"


### PR DESCRIPTION
I've been packaging onload as .deb for internal use (Ubuntu 20.04 through 24.04) and ran into a few issues with the current debian templates that this series tries to address.

Problems I hit:

- DKMS modules weren't making it into the initramfs, so in-tree sfc would load instead of the DKMS-built one at boot.
- No way to customise the DKMS build (extra dkms.conf options, quilt patches, Makefile override) without forking the templates.
- The postinst/prerm scripts hand-roll dkms calls instead of using dh_dkms.
- pybuild calls are unconditional, which breaks builds for <=9.1 (no pyproject.toml).

The commits are split roughly by feature:

- `env pwd` portability fix (minor, separate concern)
- Configurable debian revision via `--debian-revision` / `DEBIAN_REVISION`
- Hooks for `debian/Makefile`, `debian/dkms.append.conf`, and  `debian/patches` applied into the DKMS source tree. dkms.append.conf lets downstream extend dkms.conf at build time without patching upstream (e.g. declaring BUILD_DEPENDS on out-of-tree drivers like xilinx-efct, or setting BUILD_EXCLUSIVE_KERNEL).
- dh_dkms integration with backwards compat for 20.04
- initramfs-tools hook + modules-load.d + dpkg trigger on xilinx-efct-dkms
- Guard pybuild behind pyproject.toml existence check. Restore `--python-layout=deb` for older releases that still use setup.py.

Tested with onload 9.1.0.24 on Ubuntu 24.04. All five packages built successfully.

Ubuntu 26.04 support: The initramfs hook targets initramfs-tools (24.04 and earlier). Ubuntu 26.04 defaults to dracut, which handles DKMS module priority natively via updates/dkms/, so a dracut module may not be needed.