### PR TITLE
onload-devel: ship an open_onload.pc pkg-config file

### DIFF
--- a/scripts/onload_install
+++ b/scripts/onload_install
@@ -477,6 +477,24 @@ install_all_headers() {
     install_f "$oo_version_hdr" "$i_include/onload/onload_version.h"
     rm "$oo_version_hdr"
   fi
+
+  install_pkgconfig
+}
+
+
+# Render and install the pkg-config file for the Onload extensions library.
+# The version is taken from onload_version_gen, the same source used for
+# onload_version.h above, so the .pc Version tracks the packaged release.
+install_pkgconfig() {
+  local template="$TOP/scripts/onload_misc/open_onload.pc.in"
+  local version
+  version=$(onload_version_gen |
+    sed -n 's/.*#define ONLOAD_VERSION[[:space:]]*"\([^ "]*\).*/\1/p')
+  local pc
+  pc=$(mktemp)
+  try sed "s/@VERSION@/$version/" "$template" > "$pc"
+  install_f "$pc" "$i_lib64/pkgconfig/open_onload.pc"
+  rm "$pc"
 }
 
 conflict() {

--- a/scripts/onload_misc/open_onload.pc.in
+++ b/scripts/onload_misc/open_onload.pc.in
@@ -1,0 +1,18 @@
+# SPDX-License-Identifier: BSD-2-Clause
+# X-SPDX-Copyright-Text: (c) Copyright 2025 Advanced Micro Devices, Inc.
+#
+# pkg-config template for the Onload extensions library.  The version token
+# below is substituted by scripts/onload_install when the development headers
+# are installed (see install_pkgconfig).
+prefix=/usr
+exec_prefix=${prefix}
+libdir=${prefix}/lib64
+includedir=${prefix}/include/onload
+install_suffix=
+
+Name: OpenOnload
+Description: Onload is a high performance user-level network stack, which accelerates TCP and UDP network I/O for applications using the BSD sockets on Linux.
+URL: https://github.com/Xilinx-CNS/onload
+Version: @VERSION@
+Cflags: -I${includedir}
+Libs: -L${libdir} -lonload_ext${install_suffix}

--- a/scripts/onload_misc/openonload.spec
+++ b/scripts/onload_misc/openonload.spec
@@ -279,6 +279,7 @@ This package comprises development headers for the components of OpenOnload.
 
 %files devel
 %defattr(-,root,root)
+%{_libdir}/pkgconfig/open_onload.pc
 %{_includedir}/ci
 %{_includedir}/cplane
 %{_includedir}/etherfabric


### PR DESCRIPTION
### Summary

Onload ships the extensions library (`libonload_ext`) and its header (`onload/extensions.h`) in the devel package, but nothing tells `pkg-config` they exist. Anything that wants to build against Onload has to hardcode
`-lonload_ext` and the include path by hand. This adds a proper `open_onload.pc` so a downstream build can just do
`pkg-config --cflags --libs open_onload` and get the right flags. 

We've been carrying this as a local spec-file patch for a while (a `cat <<EOF` heredoc bolted into `%install` that writes the `.pc` inline). It works, but it only ever helped us and was a manual update each time. Here's a pull request so we don't have to be responsible for doing this ourselves forever :) 

# New files and changes

Impact is really targeted and only touches what's necessary to reach parity with what we've been doing internally for a while:

- **`scripts/onload_misc/open_onload.pc.in`** (new) - a real, tracked template with a `@VERSION@` token. `onload_mkdist` already copies the whole   `onload_misc/` directory into the tarball, so no mkdist change is needed.

- **`scripts/onload_install`** - a small `install_pkgconfig` function called from the headers flow. It renders the template, substitutes the version, and installs via `install_f` so the file is tracked in the uninstall manifest like every other `onload_misc/` file. The version comes from `onload_version_gen`, the same source already used two lines up for `onload_version.h`, so the `.pc` `Version:` tracks the packaged release.

- **`scripts/onload_misc/openonload.spec`** - one line in `%files devel` listing the file.

This update will work for debian installs as well, I think. It looks like `debian/rules` installs devel files through the
same `scripts/onload_install --headers` call, so RPM and DEB *should* both pick up the `.pc` from one place.

# Testing

Built the full RPM set from a clean tree on RHEL 9:

    ./scripts/onload_mkpackage --rpm --version 9.0.2 --verbose --kernel-package-deps

The file lands in the devel package at the expected path:

    $ rpm -qpl onload-devel-9.0.2-1.el9.noarch.rpm | grep pkgconfig
    /usr/lib64/pkgconfig/open_onload.pc

Because it's now a well-formed `.pc` in the standard location, RPM's own
dependency generator picks it up without any help:

    $ rpm -qp --provides onload-devel-9.0.2-1.el9.noarch.rpm | grep pkgconfig
    pkgconfig(open_onload) = 9.0.2
    $ rpm -qp --requires onload-devel-9.0.2-1.el9.noarch.rpm | grep pkg-config
    /usr/bin/pkg-config

Rendered contents, with the version substituted from `onload_version_gen`:

    prefix=/usr
    exec_prefix=${prefix}
    libdir=${prefix}/lib64
    includedir=${prefix}/include/onload
    install_suffix=

    Name: OpenOnload
    Description: Onload is a high performance user-level network stack, which accelerates TCP and UDP network I/O for applications using the BSD sockets on Linux.
    URL: https://github.com/Xilinx-CNS/onload
    Version: 9.0.2
    Cflags: -I${includedir}
    Libs: -L${libdir} -lonload_ext${install_suffix}

# Debian notes

I have not built the Debian packages myself, so a second pair of eyes on the DEB devel package would be welcome (the code path is shared, but I'd rather someone confirm than take my word for it).

