### PR TITLE
Implement "explicit wild" endpoints

### DIFF
--- a/src/include/ci/internal/ip.h
+++ b/src/include/ci/internal/ip.h
@@ -1180,9 +1180,13 @@ extern int ci_pipe_list_to_iovec(ci_netif* ni, struct oo_pipe* p,
 /* Set in a socket that is used as the owner for an active wild filter */
 #define CI_TCP_STATE_ACTIVE_WILD (0xe000)
 
+/* Set in a socket that is used as the owner for an explicit wild filter */
+#define CI_TCP_STATE_EXPLICIT_WILD (0xe000 | CI_TCP_STATE_NOT_CONNECTED)
+
 
 /* Convert state to number in range 0->0xe */
-#define CI_TCP_STATE_NUM(s)    (((s) & 0xf000) >> 12u)
+#define CI_TCP_STATE_MASK      0xf000
+#define CI_TCP_STATE_NUM(s)    (((s) & CI_TCP_STATE_MASK) >> 12u)
 
 
 /* Flags we don't expect to see in normal data packets. */

--- a/src/include/ci/internal/more_stats.h
+++ b/src/include/ci/internal/more_stats.h
@@ -35,7 +35,7 @@ static inline void get_more_stats(ci_netif* ni, more_stats_t* s)
     }
     ++s->states[CI_TCP_STATE_NUM(state)];
     if( state == CI_TCP_STATE_FREE || state == CI_TCP_STATE_AUXBUF ||
-        state == CI_TCP_STATE_ACTIVE_WILD )
+        (state & CI_TCP_STATE_MASK) == CI_TCP_STATE_ACTIVE_WILD )
       continue;
     if( w->sb_aflags & CI_SB_AFLAG_ORPHAN       )  ++s->sock_orphans;
     if( w->wake_request & CI_SB_FLAG_WAKE_RX )  ++s->sock_wake_needed_rx;

--- a/src/include/ci/internal/opts_netif_def.h
+++ b/src/include/ci/internal/opts_netif_def.h
@@ -1844,3 +1844,15 @@ CI_CFG_STR_OPT("EF_ONLOAD_IRQ_CORES", onload_irq_cores, ci_string256,
 "of CPU ranges, similar to the format used by the kernel for CPU masks \n"
 "(e.g., \"0-3,8-11\" or \"0,2,4,6\").\n",
                ,  , "", none, none, )
+
+CI_CFG_STR_OPT("EF_TCP_EXPLICIT_WILD_PORTS", tcp_explicit_wild_ports, ci_string256,
+"Preallocate and hold filters rules for listening ports.\n"
+"Normally the filter is deleted when the listener and all connections to "
+"the port is closed, but this option allows the filter to be reused for "
+"the lifetime of this Onload stack. Doing this removes the filter installation "
+"from the bind/listen/close operations, which improves their performance.\n"
+"The format to this variable is a list of port ranges in the form of "
+"1,3-4,10-10. Onload clustering is not supported, and you must avoid outgoing "
+"connections to be randomly allocated ports from using one of these given ports "
+"by using sysctl net.ipv4.ip_local_port_range or net.ipv4.ip_local_reserved_ports.",
+               ,  , "", none, none, )

--- a/src/lib/efthrm/tcp_helper_resource.c
+++ b/src/lib/efthrm/tcp_helper_resource.c
@@ -3985,6 +3985,65 @@ tcp_helper_alloc_list_to_aw_pool(tcp_helper_resource_t* rs,
 }
 #endif
 
+static int
+tcp_helper_alloc_tcp_explicit_wild_ports(tcp_helper_resource_t* rs,
+                                         ci_netif* ni)
+{
+  const int nr_ports = 65536;
+  tcp_helper_endpoint_t* ep;
+  unsigned long* bitmap;
+  citp_waitable_obj* wo;
+  uint16_t port;
+  int idx, rc;
+
+  bitmap = kvmalloc_array(BITS_TO_LONGS(nr_ports), sizeof(*bitmap), GFP_KERNEL);
+  if( !bitmap )
+    return -ENOMEM;
+
+  rc = bitmap_parselist(NI_OPTS(ni).tcp_explicit_wild_ports, bitmap, nr_ports);
+  if( rc )
+    goto err_free;
+
+  for_each_set_bit(idx, bitmap, nr_ports) {
+    /* This could potentially take a long time, allow user to terminate.
+     * For normal signals such as SIGINT, citp_signal_intercept would just
+     * restart the ioctl, so only handle fatal signals here */
+    if( fatal_signal_pending(current) ) {
+      rc = -EINTR;
+      goto err_free;
+    }
+
+    port = htons(idx);
+
+    wo = citp_waitable_obj_alloc(ni);
+    if( !wo ) {
+      rc = -ENOBUFS;
+      goto err_free;
+    }
+
+    ci_sock_cmn_init(ni, &wo->sock, 1);
+    wo->sock.b.state = CI_TCP_STATE_EXPLICIT_WILD;
+#if CI_CFG_IPV6
+    wo->sock.pkt.ether_type = CI_ETHERTYPE_IP6;
+#endif
+
+    sock_protocol(&wo->sock) = IPPROTO_TCP;
+    ci_sock_set_laddr_port(&wo->sock, addr_any, port);
+    ci_sock_set_raddr_port(&wo->sock, addr_any, 0);
+
+    ep = ci_trs_get_valid_ep(rs, W_SP(&wo->waitable));
+    rc = tcp_helper_endpoint_set_filters(ep, CI_IFID_BAD, OO_SP_NULL);
+    if( rc != 0 && rc != -EFILTERSSOME )
+      goto err_free;
+  }
+
+  kvfree(bitmap);
+  return 0;
+
+err_free:
+  kvfree(bitmap);
+  return rc;
+}
 
 /* These hashing functions are the same as for the per-stack active-wild table,
  * but there's no reason why they have to be, and so in the interests of
@@ -4896,6 +4955,31 @@ int tcp_helper_rm_alloc(ci_resource_onload_alloc_t* alloc,
       nic = efrm_client_get_nic(rs->nic[intf_i].thn_oo_nic->efrm_client);
       if( nic->flags & NIC_FLAG_LLCT )
         ci_atomic32_or(&nsn->nic_error_flags, CI_NETIF_NIC_ERROR_AWAITING_EFCT);
+    }
+  }
+
+  /* This is done before setting rs->thc so we can fail the stack creation on error.
+   * Clustering support is explicitly disabled */
+  if( NI_OPTS(ni).tcp_explicit_wild_ports[0] != '\0' ) {
+    if( thc ) {
+      OO_DEBUG_ERR(ci_log("%s: [%d] Cannot use explicit wilds with clustering.",
+                          __func__, NI_ID(ni)));
+      rc = -EINVAL;
+      goto fail13;
+    }
+
+    rc = tcp_helper_alloc_tcp_explicit_wild_ports(rs, ni);
+    if( rc != 0 ) {
+      OO_DEBUG_ERR(ci_log("%s: [%d] Failed to allocate explicit wild ports rc=%d.",
+                          __func__, NI_ID(ni), rc));
+
+      /* EEXIST specifically means stack name is in use, causing stack creation
+       * to be retried, so don't pass this error code along, rather use a generic
+       * error code instead.
+       */
+      if( rc == -EEXIST )
+        rc = -EPERM;
+      goto fail13;
     }
   }
 

--- a/src/lib/transport/ip/netif_dtor.c
+++ b/src/lib/transport/ip/netif_dtor.c
@@ -115,7 +115,7 @@ ci_uint32 oo_netif_apps_gone(ci_netif* netif)
      * all their users have gone in the stack dtor.
      */
     if( w->state == CI_TCP_STATE_FREE || w->state == CI_TCP_STATE_AUXBUF ||
-        w->state == CI_TCP_STATE_ACTIVE_WILD )
+        (w->state & CI_TCP_STATE_MASK) == CI_TCP_STATE_ACTIVE_WILD )
       continue;
 
     if( w->state == CI_TCP_CLOSED ) {

--- a/src/lib/transport/ip/netif_init.c
+++ b/src/lib/transport/ip/netif_init.c
@@ -1364,6 +1364,9 @@ void ci_netif_config_opts_getenv(ci_netif_config_opts* opts)
 
   if( (s = getenv("EF_ENABLE_TX_ERROR_RECOVERY")) )
     opts->tx_error_recovery = atoi(s);
+
+  handle_str_opt(opts, "EF_TCP_EXPLICIT_WILD_PORTS", opts->tcp_explicit_wild_ports,
+                 sizeof(opts->tcp_explicit_wild_ports));
 }
 
 

--- a/src/lib/transport/ip/tcp_misc.c
+++ b/src/lib/transport/ip/tcp_misc.c
@@ -151,7 +151,7 @@ const char* ci_tcp_state_num_str(int state_i)
     "UDP",
     "PIPE",
     "AUXBUF",
-    "ACTIVE_WILD",
+    "WILD",
   };
 
   if( state_i < 0 || state_i >= (sizeof(state_strs) / sizeof(state_strs[0])) )

--- a/src/lib/transport/ip/tcp_rx.c
+++ b/src/lib/transport/ip/tcp_rx.c
@@ -4670,6 +4670,10 @@ static int ci_tcp_rx_deliver_to_listen(ci_sock_cmn* s, void* opaque_arg)
     rxp->pkt = NULL;
     return 1;
   }
+  else if( s->b.state == CI_TCP_STATE_EXPLICIT_WILD ) {
+    /* Explicit wilds are non-matching */
+    return 0;
+  }
 
   handle_rx_listen(rxp->ni, SOCK_TO_TCP_LISTEN(s), rxp, 0);
   rxp->pkt = NULL;

--- a/src/lib/transport/ip/waitable.c
+++ b/src/lib/transport/ip/waitable.c
@@ -321,6 +321,7 @@ const char* citp_waitable_type_str(citp_waitable* w)
   else if( w->state == CI_TCP_STATE_PIPE )  return "PIPE";
   else if( w->state == CI_TCP_STATE_AUXBUF )  return "AUXBUFS";
   else if( w->state == CI_TCP_STATE_ACTIVE_WILD )  return "ACTIVE_WILD";
+  else if( w->state == CI_TCP_STATE_EXPLICIT_WILD )  return "EXPLICIT_WILD";
   else return "<unknown-citp_waitable-type>";
 }
 
@@ -332,7 +333,7 @@ static void citp_waitable_dump2(ci_netif* ni, citp_waitable* w, const char* pf,
   ci_sock_cmn* s = NULL;
 
   if( CI_TCP_STATE_IS_SOCKET(w->state) ||
-      w->state == CI_TCP_STATE_ACTIVE_WILD) {
+      (w->state & CI_TCP_STATE_MASK) == CI_TCP_STATE_ACTIVE_WILD ) {
     s = CI_CONTAINER(ci_sock_cmn, b, w);
     logger(log_arg, "%s%s "NT_FMT"lcl="OOF_IPXPORT" rmt="OOF_IPXPORT" %s",
            pf, citp_waitable_type_str(w), NI_ID(ni), W_FMT(w),
@@ -345,7 +346,7 @@ static void citp_waitable_dump2(ci_netif* ni, citp_waitable* w, const char* pf,
            citp_waitable_type_str(w), NI_ID(ni), W_FMT(w));
 
   if( w->state == CI_TCP_STATE_FREE || w->state == CI_TCP_STATE_AUXBUF ||
-      w->state == CI_TCP_STATE_ACTIVE_WILD )
+      (w->state & CI_TCP_STATE_MASK) == CI_TCP_STATE_ACTIVE_WILD )
     return;
 
   tmp = w->lock.wl_val;
@@ -382,7 +383,7 @@ void citp_waitable_dump_to_logger(ci_netif* ni, citp_waitable* w,
 
   citp_waitable_dump2(ni, w, pf, logger, log_arg);
   if( CI_TCP_STATE_IS_SOCKET(w->state) ) {
-    if( w->state == CI_TCP_STATE_ACTIVE_WILD )
+    if( (w->state & CI_TCP_STATE_MASK) == CI_TCP_STATE_ACTIVE_WILD )
       return;
 
     ci_sock_cmn_dump(ni, &wo->sock, pf, logger, log_arg);


### PR DESCRIPTION
It's been observed that for some NICs, flow steering configuration (which is needed for AF_XDP) is a slow control-path process, taking milliseconds. And as a result, opening a listening port and closing causes unreasonable delays in the processing, especially with the `ci_netif_lock(ep->netif)` lock held for the entire duration. For outgoing sockets, there exist the workaround of "active wilds" (EF_TCP_SHARED_LOCAL_PORTS), but for listeners, no such workaround exist.

This patch adds a new state CI_TCP_STATE_EXPLICIT_WILD = CI_TCP_STATE_ACTIVE_WILD | CI_TCP_STATE_NOT_CONNECTED, turning CI_TCP_STATE_ACTIVE_WILD sort of into a bitmasked value. Common code between active wilds and explicit wilds now check for that value after masking.

The new endpoint state is always orphaned (no fd), only creatable on stack creation, and is always non-matching for packet delivery to endpoints (allowing the packet to be sent to kernel sockets listening on the same port). It also never has a kernel socket attached, this is so that someone can connect to it and see that the the connection is refused, rather than being delivered to a socket that will not respond. As a result, user has to explicitly make sure that those sockets are not used for other outgoing sockets via sysctls.

User passes the list of ports for explicit wilds in the env variable `EF_TCP_EXPLICIT_WILD_PORTS`, in the format of what bitmap_parselist accepts.